### PR TITLE
added links to wiki documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,9 @@ Example
 -------
 
 For more information, see the
-`REFERENCE.md <//github.com/mwclient/mwclient/blob/master/REFERENCE.md>`_ file.
+`REFERENCE.md <//github.com/mwclient/mwclient/blob/master/REFERENCE.md>`_ file
+or the 
+`documentation on the wiki <//github.com/mwclient/mwclient/wiki.`_
 
 .. code-block:: python
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -110,4 +110,6 @@ Default chunk size is generally the maximum chunk size.
 
 ## Links ##
 * Project page at GitHub: https://github.com/mwclient/mwclient
+* More in-depth documentation on the GitHub wiki: 
+https://github.com/mwclient/mwclient/wiki
 * MediaWiki API documentation: https://mediawiki.org/wiki/API


### PR DESCRIPTION
There weren't any links to the documentation wiki. Now there are!
