### PR TITLE
Filtering links by namespace not working

### DIFF
--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -320,7 +320,9 @@ class Page(object):
         return listing.PageProperty(self, 'langlinks', 'll', return_values=('lang', '*'), **kwargs)
 
     def links(self, namespace=None, generator=True, redirects=False):
-        kwargs = dict(listing.List.generate_kwargs('gpl', namespace=namespace))
+        prefix = listing.List.get_prefix('pl', generator)
+        kwargs = dict(listing.List.generate_kwargs(prefix, namespace=namespace))
+
         if redirects:
             kwargs['redirects'] = '1'
         if generator:


### PR DESCRIPTION
When listing links from a specific namespace, API was returning the following warning:

```
Unrecognized parameter: 'plnamespace'.
```

And links from any namespace were returned. Replaced by 'gplnamespace' and namespace filtering works again.
