### PR TITLE
Adds six as requirement. It solves "ImportError: No module named six"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class PyTest(TestCommand):
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 
-requirements = ['requests']
+requirements = ['requests', 'six']
 if sys.version_info < (2, 7):
     requirements.append('ordereddict')
 


### PR DESCRIPTION
Six is a requirement for mwclilent. 
Platform: Ubuntu 14.04
Python: 2.7.8
