### PR TITLE
cache page text until next edit operation

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -238,6 +238,17 @@ class TestPageApiArgs(unittest.TestCase):
             'rvlimit': '1'
         }
 
+    def test_get_page_text_cached(self):
+        # Check page.text() caching
+        self.page.revisions = mock.Mock(return_value=iter([]))
+        self.page.text()
+        self.page.text()
+        # When cache is hit, revisions is not, so call_count should be 1
+        assert self.page.revisions.call_count == 1
+        self.page.text(cache=False)
+        # With cache explicitly disabled, we should hit revisions
+        assert self.page.revisions.call_count == 2
+
     def test_get_section_text(self):
         # Check that the 'rvsection' parameter is sent to the API
         text = self.page.text(section=0)


### PR DESCRIPTION
Store the results of page.text() operations in a simple cache dict. This avoids unnecessary remote roundtrips. Cache is cleared on each successful page save operation; we might want to also have a method to clear the cache, TTL, whatever, if folks are likely to keep Page instances around a long time and need to refresh them for possible third party edits.

This also gets rid of the section attribute, which looks bogus to me. All it appears to achieve is that if you retrieve the text of a particular section, then run a 'save' operation without explicitly specifying a section, the save operation is applied to the same section. This seems a completely wrong and potentially dangerous assumption. Maybe I'm missing something, though.

This is a pretty simple-minded implementation I wouldn't necessarily expect to get merged as-is, view it as a proof-of-concept / prototype rather than something really mergeable, I think. Just wanted to provide a bit more flesh than simply a feature request. My use case for this is a case where I want to sort of assemble a set of distinct edits to a page before firing them all together, and in order to figure out all the edits, I have to poke through the existing page text for each distinct one, finding the appropriate bit to change.