### PR TITLE
drop Page.section attribute: it does wrong things

### DIFF
--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -15,7 +15,6 @@ class Page(object):
             return self.__dict__.update(name.__dict__)
         self.site = site
         self.name = name
-        self.section = None
 
         if not info:
             if extra_properties:
@@ -137,11 +136,9 @@ class Page(object):
         try:
             rev = revs.next()
             text = rev['*']
-            self.section = section
             self.last_rev_time = rev['timestamp']
         except StopIteration:
             text = u''
-            self.section = None
             self.last_rev_time = None
         if not expandtemplates:
             self.edit_time = time.gmtime()
@@ -160,9 +157,6 @@ class Page(object):
             raise errors.UserBlocked(self.site.blocked)
         if not self.can('edit'):
             raise errors.ProtectedPageError(self)
-
-        if not section:
-            section = self.section
 
         if not self.site.writeapi:
             raise errors.NoWriteApi(self)


### PR DESCRIPTION
This attribute (I think) goes back to an older design, where
the 'edit page' workflow was different: the edit() method did
part of the work of defining what text you meant to edit. In
the current workflow, text() - which replaced the deprecated
edit() - is only for retrieving text, and save() is supposed
to do all the work of editing the page.

The 'section' attribute is therefore obsolete and dangerous,
because what it does is this: if you ever call text() and pass
the 'section' argument, then later call save() without passing
the 'section' argument, it assumes you want to save the same
section you retrieved with text(). That doesn't seem to be a
valid assumption with the expected and currently-documented
behaviour of text() and save(), and could lead to unexpected
and confusing results (for e.g. you intended to rewrite the
page entirely without reference to the contents of the section
you retrieved).

This change should be documented as a BC break, though, as it
is possible there are still users relying on the old design
and not passing 'section' when they call save().