### PR TITLE
including a function to return revisions and allow for diffto

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -696,6 +696,25 @@ class Site(object):
                                                    toponly='1' if toponly else None))
         return listing.List(self, 'recentchanges', 'rc', limit=limit, **kwargs)
 
+    def revisions(self, revids, prop = 'ids|timestamp|flags|comment|user', 
+                  expandtemplates=False, diffto='prev'):
+            self.require(1, 12) # version?
+            if expandtemplates: expandtemplates = '1'
+            # http://en.wikipedia.org/w/api.php?rvexpandtemplates=False&format=json&list=&rvprop=ids|timestamp|flags|comment|user&rvdiffto=prev&revids=396240352|392544274|396332337&meta=userinfo&action=query&prop=revisions&uiprop=blockinfo|hasmsg
+            revids_s = '|'.join(map(str,revids))
+            kwargs = {'prop':'revisions','rvexpandtemplates':expandtemplates,'format':'json','rvprop':prop,
+                      'rvdiffto':diffto, 'revids':revids_s}
+            if (diffto is None) or (diffto == ''):
+                del kwargs['rvdiffto']
+            if (expandtemplates is None) or (expandtemplates == '') or (expandtemplates == 0):
+                del kwargs['rvexpandtemplates']
+            res = self.api('query', **kwargs)
+
+            if res.has_key('query'):
+                return res['query']
+            else:
+                return None
+                
     def search(self, search, namespace='0', what='title', redirects=False, limit=None):
 
         kwargs = dict(listing.List.generate_kwargs('sr', search=search, namespace=namespace, what=what))

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -332,9 +332,9 @@ class Page(object):
 
     def revisions(self, startid=None, endid=None, start=None, end=None,
                   dir='older', user=None, excludeuser=None, limit=50,
-                  prop='ids|timestamp|flags|comment|user', expandtemplates=False, section=None):
+                  prop='ids|timestamp|flags|comment|user', expandtemplates=False, section=None, diffto = None):
         kwargs = dict(listing.List.generate_kwargs('rv', startid=startid, endid=endid,
-                                                   start=start, end=end, user=user, excludeuser=excludeuser))
+                                                   start=start, end=end, user=user, excludeuser=excludeuser, diffto=diffto))
         kwargs['rvdir'] = dir
         kwargs['rvprop'] = prop
         if expandtemplates:


### PR DESCRIPTION
A long while ago, I got a request from @waldyrious to integrate [changes I had made in my clone of mwclient](https://bitbucket.org/rdhyee/mwclient/branch/wpp?dest=r97#chg-mwclient/page.py) into this repo. (Sorry to take so long!)   The basic change I had made was to add a `revisions` method to the `Site` object and modify the source so that I can make use of the `rvdiffto` parameter for [prop=revisions](https://en.wikipedia.org/w/api.php?action=help&modules=query%2Brevisions)

This PR is a naive integration of the code I wrote (which was based off of the 0.6.5 or r97 versions of mwclient.) I know a significant amount of the library has changed.  I welcome:

* feedback on whether this code is useful
* how to clean up this PR so as to conform to the latest structure of mwclient.