### PR TITLE
Adding pageid, contentmodel, pagelanguage, restrictiontypes as attributes of Page

### DIFF
--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -48,6 +48,7 @@ class Page(object):
         self.length = info.get('length')
         self.protection = dict([(i['type'], (i['level'], i['expiry'])) for i in info.get('protection', ()) if i])
         self.redirect = 'redirect' in info
+        self.pageid = info.get('pageid', None)
 
         self.last_rev_time = None
         self.edit_time = None

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -49,6 +49,9 @@ class Page(object):
         self.protection = dict([(i['type'], (i['level'], i['expiry'])) for i in info.get('protection', ()) if i])
         self.redirect = 'redirect' in info
         self.pageid = info.get('pageid', None)
+        self.contentmodel = info.get('contentmodel', None)
+        self.pagelanguage = info.get('pagelanguage', None)
+        self.restrictiontypes = info.get('restrictiontypes', None)
 
         self.last_rev_time = None
         self.edit_time = None


### PR DESCRIPTION
Those values are only accessible through the private dict _info. Making them available directly may be useful to mwclient users.