### PR TITLE
Wikibase client (read only)

### DIFF
--- a/mwclient/__init__.py
+++ b/mwclient/__init__.py
@@ -24,8 +24,12 @@
 """
 
 from mwclient.errors import *  # noqa: F401, F403
-from mwclient.client import Site as Site, WikiBaseSite, __version__ as __version__  # noqa: F401
-from mwclient import entity
+from mwclient.client import (  # noqa: F401
+    Site as Site,
+    WikiBaseSite as WikiBaseSite,
+    __version__ as __version__
+)
+from mwclient import entity  # noqa: F401
 import logging
 import warnings
 

--- a/mwclient/__init__.py
+++ b/mwclient/__init__.py
@@ -24,7 +24,8 @@
 """
 
 from mwclient.errors import *  # noqa: F401, F403
-from mwclient.client import Site as Site, __version__ as __version__  # noqa: F401
+from mwclient.client import Site as Site, WikiBaseSite, __version__ as __version__  # noqa: F401
+from mwclient import entity
 import logging
 import warnings
 

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -9,6 +9,7 @@ import requests
 from requests.auth import HTTPBasicAuth, AuthBase
 from requests_oauthlib import OAuth1
 
+import mwclient.entity as entity
 import mwclient.errors as errors
 import mwclient.listing as listing
 from mwclient._types import Cookies, Namespace, VersionTuple
@@ -199,6 +200,9 @@ class Site:
         self.Pages = self.pages
         self.Categories = self.categories
         self.Images = self.images
+
+        # wikibase caching
+        self._wikibase_repository = None
 
         # Initialization status
         self.initialized = False
@@ -1956,3 +1960,50 @@ class Site:
                 answers = [answer for answer in answers.values()]
 
             yield from answers
+            for answer in answers:
+                yield answer
+
+    @property
+    def wikibase_repository(self):
+        """Wiki base repository."""
+        if self._wikibase_repository is None:
+            result = self.api('query', meta='wikibase')
+            url = result['query']['wikibase']['repo']['url']
+            method = 'https'
+            host = url['base'].replace('//', '')
+            if '://' in url['base']:
+                method, host = url['base'].split('://')
+            path = url['scriptpath'] + "/"
+            self._wikibase_repository = WikiBaseSite(('https', host),
+                                                     path=path,
+                                                     pool=self.connection)
+        return self._wikibase_repository
+
+
+class WikiBaseSite(Site):
+
+    """WikiBaseSite object to access to WikiBase API."""
+
+    def __repr__(self):
+        """Representation of the WikiBaseSite object."""
+        return "<WikiBaseSite object '%s%s'>" % (self.host, self.path)
+
+    def entities(self, ids):
+        """Returns entities.
+
+        API doc: https://www.mediawiki.org/wiki/Wikibase/API/en#wbgetentities
+
+        Args:
+            ids (list): ID or IDs of the entities to fetch."""
+        result = self.api('wbgetentities', ids="|".join(ids))
+        entities = []
+        for entityid in result['entities']:
+            if result['entities'][entityid]['type'] == 'item':
+                item = entity.Item(self, entityid)
+                item.setinfofromwbgetentities(result['entities'][entityid])
+                entities.append(item)
+            elif result['entities'][entityid]['type'] == 'property':
+                prop = entity.Property(self, entityid)
+                prop.setinfofromwbgetentities(result['entities'][entityid])
+                entities.append(prop)
+        return entities

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -202,7 +202,7 @@ class Site:
         self.Images = self.images
 
         # wikibase caching
-        self._wikibase_repository = None
+        self._wikibase_repository: Optional['WikiBaseSite'] = None
 
         # Initialization status
         self.initialized = False
@@ -1964,7 +1964,7 @@ class Site:
                 yield answer
 
     @property
-    def wikibase_repository(self):
+    def wikibase_repository(self) -> 'WikiBaseSite':
         """Wiki base repository."""
         if self._wikibase_repository is None:
             result = self.api('query', meta='wikibase')
@@ -1974,9 +1974,10 @@ class Site:
             if '://' in url['base']:
                 method, host = url['base'].split('://')
             path = url['scriptpath'] + "/"
-            self._wikibase_repository = WikiBaseSite(('https', host),
-                                                     path=path,
+            self._wikibase_repository = WikiBaseSite(host, path=path, scheme=method,
                                                      pool=self.connection)
+        # forcing mypy typing
+        assert self._wikibase_repository is not None
         return self._wikibase_repository
 
 
@@ -1984,26 +1985,26 @@ class WikiBaseSite(Site):
 
     """WikiBaseSite object to access to WikiBase API."""
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Representation of the WikiBaseSite object."""
         return "<WikiBaseSite object '%s%s'>" % (self.host, self.path)
 
-    def entities(self, ids):
+    def entities(self, ids: List[str]) -> List[Union[entity.Item, entity.Property]]:
         """Returns entities.
 
         API doc: https://www.mediawiki.org/wiki/Wikibase/API/en#wbgetentities
 
         Args:
-            ids (list): ID or IDs of the entities to fetch."""
+            ids: ID or IDs of the entities to fetch."""
         result = self.api('wbgetentities', ids="|".join(ids))
-        entities = []
+        result_entities: List[Union[entity.Item, entity.Property]] = []
         for entityid in result['entities']:
             if result['entities'][entityid]['type'] == 'item':
                 item = entity.Item(self, entityid)
                 item.setinfofromwbgetentities(result['entities'][entityid])
-                entities.append(item)
+                result_entities.append(item)
             elif result['entities'][entityid]['type'] == 'property':
                 prop = entity.Property(self, entityid)
                 prop.setinfofromwbgetentities(result['entities'][entityid])
-                entities.append(prop)
-        return entities
+                result_entities.append(prop)
+        return result_entities

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1968,16 +1968,22 @@ class Site:
         """Wiki base repository."""
         if self._wikibase_repository is None:
             result = self.api('query', meta='wikibase')
+            if 'query' not in result:
+                # we could look for warning but either the query works or not
+                raise errors.WikiBaseNotFound()
             url = result['query']['wikibase']['repo']['url']
-            method = 'https'
+            # default init
+            method = self.scheme
             host = url['base'].replace('//', '')
+            # parsing from the query response
             if '://' in url['base']:
                 method, host = url['base'].split('://')
             path = url['scriptpath'] + "/"
-            self._wikibase_repository = WikiBaseSite(host, path=path, scheme=method,
-                                                     pool=self.connection)
-        # forcing mypy typing
-        assert self._wikibase_repository is not None
+            self._wikibase_repository = WikiBaseSite(
+                host,
+                path=path,
+                scheme=method,
+                pool=self.connection)
         return self._wikibase_repository
 
 

--- a/mwclient/entity.py
+++ b/mwclient/entity.py
@@ -1,0 +1,277 @@
+"""WikiBase Entities and related objects."""
+
+
+class Entity(object):
+
+    """Wikibase Entity, either Item or Property.
+
+    This class should not be implemented directly,
+    It is meant to be abstract for Item and Property.
+
+    Attributes:
+        site (WikiBaseSite): reference to a WikiBaseSite
+        entity (str): Q number of the entity.
+        descriptions (dict): dictionary containing description per language
+        labels (dict): dictionary containing labels per language
+    """
+
+    def __init__(self, site, normalized_entity):
+        """Common part of constructor for Item and Property."""
+        self.site = site
+
+        self.entity = normalized_entity
+        # caching descriptions, labels, sitelinks
+        # self._sitelinks = None
+        self._descriptions = None
+        self._labels = None
+
+        # caching claims
+        self._itemclaims = None
+
+    def setinfofromwbgetentities(self, result):
+        """Set descriptions, labels and claims from wbgetentities result."""
+        self._descriptions = dict()
+        for language in result['descriptions']:
+            lang = result['descriptions'][language]['language']
+            value = result['descriptions'][language]['value']
+            self._descriptions[lang] = value
+        self._labels = dict()
+        for language in result['labels']:
+            lang = result['labels'][language]['language']
+            value = result['labels'][language]['value']
+            self._labels[lang] = value
+        if self._itemclaims is None:
+            self._itemclaims = []
+            for prop in result['claims']:
+                for claim in result['claims'][prop]:
+                    mainsnak = claim['mainsnak']
+                    self._itemclaims.append(Claim.fromsnak(self.site,
+                                                           mainsnak))
+
+    @property
+    def labels(self):
+        """Labels dictionary per language"""
+        if self._labels is None:
+            entities = self.site.api('wbgetentities', ids=self.entity)
+            result = entities['entities'][self.entity]
+            self.setinfofromwbgetentities(result)
+        return self._labels
+
+    @property
+    def descriptions(self):
+        """Descriptions dictionary per language"""
+        if self._descriptions is None:
+            entities = self.site.api('wbgetentities', ids=self.entity)
+            result = entities['entities'][self.entity]
+            self.setinfofromwbgetentities(result)
+        return self._descriptions
+
+    def claims(self, prop=None):
+        """Claims about an Entity.
+
+        API Doc: https://www.mediawiki.org/wiki/Wikibase/API/en#wbgetclaims
+        We will probably need to implement rank and props later on.
+
+        Args:
+            prop (list, optional): list of property e.g. ['P238', 'P239']
+        """
+        if self._itemclaims is None:
+            self._itemclaims = []
+            info = self.site.api('wbgetclaims', entity=self.entity)['claims']
+
+            for propid in info:
+                for claim in info[propid]:
+                    mainsnak = claim['mainsnak']
+                    self._itemclaims.append(Claim.fromsnak(self.site,
+                                                           mainsnak))
+        if prop is None:
+            return self._itemclaims
+        else:
+            return [claim for claim in self._itemclaims if claim.prop in prop]
+
+
+class Item(Entity):
+
+    """Wikibase Item.
+
+    Attributes:
+        site (WikiBaseSite): reference to a WikiBaseSite
+        entity (str): Q number of the entity.
+        sitelinks (dict): dictionary containing sitelinks per wiki
+        descriptions (dict): dictionary containing description per language
+        labels (dict): dictionary containing labels per language
+    """
+
+    def __init__(self, site, entity):
+        """Constructor.
+
+        Args:
+            site (WikiBaseSite): reference to a WikiBaseSite
+            entity (str): Q number of the entity.
+        """
+        # Normalizing entity name
+        super(Item, self).__init__(site, 'Q' + entity.upper().lstrip('Q'))
+
+        self._sitelinks = None
+
+    def setinfofromwbgetentities(self, result):
+        """Set sitelinks, descriptions, labels, claims from wbgetentities."""
+        super(Item, self).setinfofromwbgetentities(result)
+        self._sitelinks = dict()
+        for wiki in result['sitelinks']:
+            site = result['sitelinks'][wiki]['site']
+            title = result['sitelinks'][wiki]['title']
+            badges = result['sitelinks'][wiki]['badges']
+            self._sitelinks[site] = {'title': title, 'badges': badges}
+
+    @property
+    def sitelinks(self):
+        """Sitelinks dictionary with title, and badges per site.
+
+        Example:
+            >>> import mwclient
+            >>> site = mwclient.WikiBaseSite(('https', 'www.wikidata.org'))
+            >>> q = mwclient.entity.Item(site, 'Q3340172')
+            >>> q.sitelinks
+        """
+        if self._sitelinks is None:
+            entities = self.site.api('wbgetentities', ids=self.entity)
+            result = entities['entities'][self.entity]
+            self.setinfofromwbgetentities(result)
+        return self._sitelinks
+
+    def __repr__(self):
+        """Item representation."""
+        return "<Item object %s (%s)>" % (self.entity, self.site.host)
+
+
+class Property(Entity):
+
+    """Wikibase Property."""
+
+    def __init__(self, site, entity):
+        """Constructor.
+
+        Args:
+            site (WikiBaseSite): reference to a WikiBaseSite
+            entity (str): Q number of the entity.
+        """
+        # Normalizing entity name
+        super(Property, self).__init__(site, 'P' + entity.upper().lstrip('P'))
+
+    def __repr__(self):
+        """Property representation."""
+        return "<Property object %s (%s)>" % (self.entity, self.site.host)
+
+
+class Claim(object):
+
+    """Claim
+
+    Attributes:
+        prop (str): property id.
+        snak (dict): snak with all values return in mainsnak from API call.
+        snaktype (str): 'value', 'somevalue' or 'novalue'
+        datatype (str): datatype ('wikibase-item', 'string', etc.)
+        raw_value (dict): content of snak['datavalue']['value'] if snaktype is
+            'value', None othewise.
+        value (object): typed content of snak['datavalue']['value']
+    """
+
+    def __init__(self, site, prop, datatype, snaktype, raw_value=None, snak=None):
+        """Constructor"""
+        self.site = site
+        self.prop = prop
+        self.datatype = datatype
+        self.raw_value = raw_value
+        self.snaktype = snaktype
+        self.snak = snak
+
+    @classmethod
+    def fromsnak(cls, site, snak):
+        """Claim from snak dictionary.
+
+        Args:
+            site (mwclient.WikiBaseSite): site
+            snak (dict): snak dictionary
+        """
+        snakvalue = None
+        if snak['snaktype'] == 'value':
+            snakvalue = snak['datavalue']['value']
+        return cls(site, snak['property'],
+                   snak['datatype'],
+                   snak['snaktype'],
+                   raw_value=snakvalue,
+                   snak=snak)
+
+    def __repr__(self):
+        """Representation."""
+        return "<Claim object %s [%s]>" % (self.prop, self.datatype)
+
+
+    @property
+    def value(self):
+        if self.datatype == 'string':
+            return self.raw_value
+        elif self.datatype == 'monolingualtext':
+            return MonolingualText(**self.raw_value)
+        elif self.datatype == 'commonsMedia':
+            return self.raw_value
+        elif self.datatype == 'external-id':
+            return self.raw_value
+        elif self.datatype == 'wikibase-item':
+            return Item(self.site, str(self.raw_value['numeric-id']))
+        elif self.datatype == 'wikibase-property':
+            return Property(self.site, str(self.raw_value['numeric-id']))
+        elif self.datatype == 'globe-coordinate':
+            return GlobeCoordinate(**self.raw_value)
+        elif self.datatype == 'time':
+            return TimeData(**self.raw_value)
+        elif self.datatype == 'quantity':
+            return Quantity(**self.raw_value)
+        else:
+            return self.raw_value
+
+
+class GlobeCoordinate(object):
+    def __init__(self, latitude=None, longitude=None, altitude=None, precision=None,
+                 globe=None):
+        self.latitude = latitude
+        self.longitude = longitude
+        self.altitude = altitude
+        self.precision = precision
+        self.globe = globe
+
+    def __repr__(self):
+        return "<GlobeCoordinate {}... {}... {}... ...>".format(
+            self.latitude,
+            self.longitude,
+            self.altitude)
+
+
+class TimeData(object):
+    def __init__(self, time=None, timezone=None, before=None, after=None, precision=None,
+                 calendarmodel=None):
+        self.time = time
+        self.timezone = timezone
+        self.before = before
+        self.after = after
+        self.precision = precision
+        self.calendarmodel = calendarmodel
+
+
+class Quantity(object):
+    def __init__(self, amount=None, unit=None, upperBound=None, lowerBound=None):
+        self.amount = amount
+        self.unit = unit
+        self.upperBound = upperBound
+        self.lowerBound = lowerBound
+
+
+class MonolingualText(object):
+    def __init__(self, text=None, language=None):
+        self.text = text
+        self.language = language
+
+    def __repr__(self):
+        return "<MonolingualText [%s] '%s'>" % (self.language, self.text)

--- a/mwclient/entity.py
+++ b/mwclient/entity.py
@@ -1,41 +1,39 @@
 """WikiBase Entities and related objects."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
 
 
-class Entity(object):
-
+class Entity:
     """Wikibase Entity, either Item or Property.
 
     This class should not be implemented directly,
     It is meant to be abstract for Item and Property.
 
     Attributes:
-        site (WikiBaseSite): reference to a WikiBaseSite
-        entity (str): Q number of the entity.
-        descriptions (dict): dictionary containing description per language
-        labels (dict): dictionary containing labels per language
+        site: reference to a WikiBaseSite
+        entity: Q/P number of the entity.
+        descriptions: dictionary containing description per language
+        labels: dictionary containing labels per language
     """
 
-    def __init__(self, site, normalized_entity):
+    def __init__(self, site: Any, normalized_entity: str) -> None:
         """Common part of constructor for Item and Property."""
         self.site = site
-
         self.entity = normalized_entity
-        # caching descriptions, labels, sitelinks
-        # self._sitelinks = None
-        self._descriptions = None
-        self._labels = None
+        self._descriptions: Optional[dict[str, str]] = None
+        self._labels: Optional[dict[str, str]] = None
+        self._itemclaims: Optional[list[Claim]] = None
 
-        # caching claims
-        self._itemclaims = None
-
-    def setinfofromwbgetentities(self, result):
+    def setinfofromwbgetentities(self, result: dict[str, Any]) -> None:
         """Set descriptions, labels and claims from wbgetentities result."""
-        self._descriptions = dict()
+        self._descriptions = {}
         for language in result['descriptions']:
             lang = result['descriptions'][language]['language']
             value = result['descriptions'][language]['value']
             self._descriptions[lang] = value
-        self._labels = dict()
+        self._labels = {}
         for language in result['labels']:
             lang = result['labels'][language]['language']
             value = result['labels'][language]['value']
@@ -45,79 +43,73 @@ class Entity(object):
             for prop in result['claims']:
                 for claim in result['claims'][prop]:
                     mainsnak = claim['mainsnak']
-                    self._itemclaims.append(Claim.fromsnak(self.site,
-                                                           mainsnak))
+                    self._itemclaims.append(Claim.fromsnak(self.site, mainsnak))
 
     @property
-    def labels(self):
+    def labels(self) -> dict[str, str]:
         """Labels dictionary per language"""
         if self._labels is None:
             entities = self.site.api('wbgetentities', ids=self.entity)
             result = entities['entities'][self.entity]
             self.setinfofromwbgetentities(result)
+        assert self._labels is not None
         return self._labels
 
     @property
-    def descriptions(self):
+    def descriptions(self) -> dict[str, str]:
         """Descriptions dictionary per language"""
         if self._descriptions is None:
             entities = self.site.api('wbgetentities', ids=self.entity)
             result = entities['entities'][self.entity]
             self.setinfofromwbgetentities(result)
+        assert self._descriptions is not None
         return self._descriptions
 
-    def claims(self, prop=None):
+    def claims(self, prop: Optional[list[str]] = None) -> list[Claim]:
         """Claims about an Entity.
 
         API Doc: https://www.mediawiki.org/wiki/Wikibase/API/en#wbgetclaims
-        We will probably need to implement rank and props later on.
 
         Args:
-            prop (list, optional): list of property e.g. ['P238', 'P239']
+            prop: list of property e.g. ['P238', 'P239']
         """
         if self._itemclaims is None:
             self._itemclaims = []
             info = self.site.api('wbgetclaims', entity=self.entity)['claims']
-
             for propid in info:
                 for claim in info[propid]:
                     mainsnak = claim['mainsnak']
-                    self._itemclaims.append(Claim.fromsnak(self.site,
-                                                           mainsnak))
+                    self._itemclaims.append(Claim.fromsnak(self.site, mainsnak))
         if prop is None:
             return self._itemclaims
-        else:
-            return [claim for claim in self._itemclaims if claim.prop in prop]
+        return [claim for claim in self._itemclaims if claim.prop in prop]
 
 
 class Item(Entity):
-
     """Wikibase Item.
 
     Attributes:
-        site (WikiBaseSite): reference to a WikiBaseSite
-        entity (str): Q number of the entity.
-        sitelinks (dict): dictionary containing sitelinks per wiki
-        descriptions (dict): dictionary containing description per language
-        labels (dict): dictionary containing labels per language
+        site: reference to a WikiBaseSite
+        entity: Q number of the entity.
+        sitelinks: dictionary containing sitelinks per wiki
+        descriptions: dictionary containing description per language
+        labels: dictionary containing labels per language
     """
 
-    def __init__(self, site, entity):
+    def __init__(self, site: Any, entity: str) -> None:
         """Constructor.
 
         Args:
-            site (WikiBaseSite): reference to a WikiBaseSite
-            entity (str): Q number of the entity.
+            site: reference to a WikiBaseSite
+            entity: Q number of the entity.
         """
-        # Normalizing entity name
-        super(Item, self).__init__(site, 'Q' + entity.upper().lstrip('Q'))
+        super().__init__(site, 'Q' + entity.upper().lstrip('Q'))
+        self._sitelinks: Optional[dict[str, dict[str, Any]]] = None
 
-        self._sitelinks = None
-
-    def setinfofromwbgetentities(self, result):
+    def setinfofromwbgetentities(self, result: dict[str, Any]) -> None:
         """Set sitelinks, descriptions, labels, claims from wbgetentities."""
-        super(Item, self).setinfofromwbgetentities(result)
-        self._sitelinks = dict()
+        super().setinfofromwbgetentities(result)
+        self._sitelinks = {}
         for wiki in result['sitelinks']:
             site = result['sitelinks'][wiki]['site']
             title = result['sitelinks'][wiki]['title']
@@ -125,60 +117,59 @@ class Item(Entity):
             self._sitelinks[site] = {'title': title, 'badges': badges}
 
     @property
-    def sitelinks(self):
-        """Sitelinks dictionary with title, and badges per site.
-
-        Example:
-            >>> import mwclient
-            >>> site = mwclient.WikiBaseSite(('https', 'www.wikidata.org'))
-            >>> q = mwclient.entity.Item(site, 'Q3340172')
-            >>> q.sitelinks
-        """
+    def sitelinks(self) -> dict[str, dict[str, Any]]:
+        """Sitelinks dictionary with title, and badges per site."""
         if self._sitelinks is None:
             entities = self.site.api('wbgetentities', ids=self.entity)
             result = entities['entities'][self.entity]
             self.setinfofromwbgetentities(result)
+        assert self._sitelinks is not None
         return self._sitelinks
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Item representation."""
         return "<Item object %s (%s)>" % (self.entity, self.site.host)
 
 
 class Property(Entity):
-
     """Wikibase Property."""
 
-    def __init__(self, site, entity):
+    def __init__(self, site: Any, entity: str) -> None:
         """Constructor.
 
         Args:
-            site (WikiBaseSite): reference to a WikiBaseSite
-            entity (str): Q number of the entity.
+            site: reference to a WikiBaseSite
+            entity: P number of the entity.
         """
-        # Normalizing entity name
-        super(Property, self).__init__(site, 'P' + entity.upper().lstrip('P'))
+        super().__init__(site, 'P' + entity.upper().lstrip('P'))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Property representation."""
         return "<Property object %s (%s)>" % (self.entity, self.site.host)
 
 
-class Claim(object):
-
+class Claim:
     """Claim
 
     Attributes:
-        prop (str): property id.
-        snak (dict): snak with all values return in mainsnak from API call.
-        snaktype (str): 'value', 'somevalue' or 'novalue'
-        datatype (str): datatype ('wikibase-item', 'string', etc.)
-        raw_value (dict): content of snak['datavalue']['value'] if snaktype is
-            'value', None othewise.
-        value (object): typed content of snak['datavalue']['value']
+        prop: property id.
+        snak: snak with all values return in mainsnak from API call.
+        snaktype: 'value', 'somevalue' or 'novalue'
+        datatype: datatype ('wikibase-item', 'string', etc.)
+        raw_value: content of snak['datavalue']['value'] if snaktype is
+            'value', None otherwise.
+        value: typed content of snak['datavalue']['value']
     """
 
-    def __init__(self, site, prop, datatype, snaktype, raw_value=None, snak=None):
+    def __init__(
+        self,
+        site: Any,
+        prop: str,
+        datatype: str,
+        snaktype: str,
+        raw_value: Any = None,
+        snak: Optional[dict[str, Any]] = None,
+    ) -> None:
         """Constructor"""
         self.site = site
         self.prop = prop
@@ -188,28 +179,31 @@ class Claim(object):
         self.snak = snak
 
     @classmethod
-    def fromsnak(cls, site, snak):
+    def fromsnak(cls, site: Any, snak: dict[str, Any]) -> Claim:
         """Claim from snak dictionary.
 
         Args:
-            site (mwclient.WikiBaseSite): site
-            snak (dict): snak dictionary
+            site: site
+            snak: snak dictionary
         """
         snakvalue = None
         if snak['snaktype'] == 'value':
             snakvalue = snak['datavalue']['value']
-        return cls(site, snak['property'],
-                   snak['datatype'],
-                   snak['snaktype'],
-                   raw_value=snakvalue,
-                   snak=snak)
+        return cls(
+            site,
+            snak['property'],
+            snak['datatype'],
+            snak['snaktype'],
+            raw_value=snakvalue,
+            snak=snak,
+        )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Representation."""
         return "<Claim object %s [%s]>" % (self.prop, self.datatype)
 
     @property
-    def value(self):
+    def value(self) -> Any:
         if self.datatype == 'string':
             return self.raw_value
         elif self.datatype == 'monolingualtext':
@@ -232,45 +226,34 @@ class Claim(object):
             return self.raw_value
 
 
-class GlobeCoordinate(object):
-    def __init__(self, latitude=None, longitude=None, altitude=None, precision=None,
-                 globe=None):
-        self.latitude = latitude
-        self.longitude = longitude
-        self.altitude = altitude
-        self.precision = precision
-        self.globe = globe
-
-    def __repr__(self):
-        return "<GlobeCoordinate {}... {}... {}... ...>".format(
-            self.latitude,
-            self.longitude,
-            self.altitude)
+@dataclass
+class GlobeCoordinate:
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    altitude: Optional[float] = None
+    precision: Optional[float] = None
+    globe: Optional[str] = None
 
 
-class TimeData(object):
-    def __init__(self, time=None, timezone=None, before=None, after=None, precision=None,
-                 calendarmodel=None):
-        self.time = time
-        self.timezone = timezone
-        self.before = before
-        self.after = after
-        self.precision = precision
-        self.calendarmodel = calendarmodel
+@dataclass
+class TimeData:
+    time: Optional[str] = None
+    timezone: Optional[int] = None
+    before: Optional[int] = None
+    after: Optional[int] = None
+    precision: Optional[int] = None
+    calendarmodel: Optional[str] = None
 
 
-class Quantity(object):
-    def __init__(self, amount=None, unit=None, upperBound=None, lowerBound=None):
-        self.amount = amount
-        self.unit = unit
-        self.upperBound = upperBound
-        self.lowerBound = lowerBound
+@dataclass
+class Quantity:
+    amount: Optional[str] = None
+    unit: Optional[str] = None
+    upperBound: Optional[str] = None
+    lowerBound: Optional[str] = None
 
 
-class MonolingualText(object):
-    def __init__(self, text=None, language=None):
-        self.text = text
-        self.language = language
-
-    def __repr__(self):
-        return "<MonolingualText [%s] '%s'>" % (self.language, self.text)
+@dataclass
+class MonolingualText:
+    text: Optional[str] = None
+    language: Optional[str] = None

--- a/mwclient/entity.py
+++ b/mwclient/entity.py
@@ -208,7 +208,6 @@ class Claim(object):
         """Representation."""
         return "<Claim object %s [%s]>" % (self.prop, self.datatype)
 
-
     @property
     def value(self):
         if self.datatype == 'string':

--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -183,3 +183,8 @@ class InvalidResponse(MwClientError):
 class InvalidPageTitle(MwClientError):
     """Raised when an invalid page title is used."""
     pass
+
+
+class WikiBaseNotFound(MwClientError):
+    """When there is no WikibaseClient installed on the local wiki."""
+    pass

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -10,7 +10,6 @@ from mwclient._types import Namespace
 from mwclient.util import parse_timestamp, handle_limit
 
 
-
 class Page:
     """
     Represents a page on a MediaWiki wiki represented by a

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -94,7 +94,7 @@ class Page:
         self.edit_time = None  # type: Optional[time.struct_time]
 
         # caching wikibase_item
-        self._wikibase_item = None
+        self._wikibase_item: Optional[Item] = None
 
     @property
     def page_title(self) -> str:
@@ -695,7 +695,7 @@ class Page:
                                                  return_values='title', **kwargs)
 
     @property
-    def wikibase_item(self):
+    def wikibase_item(self) -> Optional[Item]:
         """Item linked to a Page.
 
         if a wikibase item is linked to a page it returns this item,

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -5,8 +5,10 @@ from typing import (  # noqa: F401
 
 import mwclient.errors
 import mwclient.listing
+from mwclient.entity import Item
 from mwclient._types import Namespace
 from mwclient.util import parse_timestamp, handle_limit
+
 
 
 class Page:
@@ -91,6 +93,9 @@ class Page:
 
         self.last_rev_time = None  # type: Optional[time.struct_time]
         self.edit_time = None  # type: Optional[time.struct_time]
+
+        # caching wikibase_item
+        self._wikibase_item = None
 
     @property
     def page_title(self) -> str:
@@ -689,3 +694,26 @@ class Page:
         else:
             return mwclient.listing.PageProperty(self, 'templates', 'tl',
                                                  return_values='title', **kwargs)
+
+    @property
+    def wikibase_item(self):
+        """Item linked to a Page.
+
+        if a wikibase item is linked to a page it returns this item,
+        None otherwise."""
+        if self._wikibase_item is None:
+            info = self.site.api('query',
+                                 prop='pageprops',
+                                 titles=self.name,
+                                 ppprop='wikibase_item')['query']['pages']
+            wb_entity = None
+            for pageid in info:
+                if 'pageprops' in info[pageid]:
+                    # pageprops key is not in info if page don't have
+                    # a wikibase_item property
+                    wb_entity = info[pageid]['pageprops']['wikibase_item']
+            if wb_entity is not None:
+                self._wikibase_item = Item(
+                    self.site.wikibase_repository,
+                    wb_entity)
+        return self._wikibase_item

--- a/test/test_wikibase.py
+++ b/test/test_wikibase.py
@@ -1,0 +1,211 @@
+import unittest
+import unittest.mock as mock
+
+from mwclient.client import Site, WikiBaseSite
+from mwclient.entity import GlobeCoordinate, Item, Property
+from mwclient.page import Page
+
+
+def make_mock_wikibase_site(host: str = "www.wikidata.org") -> mock.MagicMock:
+    site = mock.MagicMock()
+    site.host = host
+    return site
+
+
+class TestPageWikibaseItem(unittest.TestCase):
+
+    @mock.patch('mwclient.client.Site')
+    def test_wikibase_item_returns_item(self, MockSite):
+        site = MockSite()
+        site.get.return_value = {
+            "query": {
+                "pages": {
+                    "1": {
+                        "title": "Paris",
+                        "ns": 0,
+                        "pageid": 1}}}}
+        page = Page(site, "Paris")
+        site.api.return_value = {
+            "query": {
+                "pages": {
+                    "1": {
+                        "pageid": 1,
+                        "pageprops": {"wikibase_item": "Q90"}}}}
+        }
+        site.wikibase_repository = make_mock_wikibase_site()
+        assert isinstance(page.wikibase_item, Item)
+        assert page.wikibase_item.entity == "Q90"
+
+
+class TestWikiBaseSiteRepr(unittest.TestCase):
+
+    def test_repr(self):
+        with mock.patch.object(WikiBaseSite, '__init__', lambda self, *a, **kw: None):
+            site = WikiBaseSite.__new__(WikiBaseSite)
+            site.host = "www.wikidata.org"
+            site.path = "/w/"
+        assert repr(site) == "<WikiBaseSite object 'www.wikidata.org/w/'>"
+
+
+class TestItemClaims(unittest.TestCase):
+
+    def setUp(self):
+        self.site = make_mock_wikibase_site()
+        self.site.api.return_value = {
+            "claims": {
+                "P625": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P625",
+                            "datatype": "globe-coordinate",
+                            "datavalue": {
+                                "value":{
+                                    "latitude": 48.86,
+                                    "longitude": 2.35,
+                                    "altitude": None,
+                                    "precision": 0.0001,
+                                    "globe":
+                                        "http://www.wikidata.org/entity/Q2"
+                                    }},}}],
+                "P150": [
+                    {
+                        "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P150",
+                        "datatype": "wikibase-item",
+                        "datavalue":{
+                            "value": {
+                                "numeric-id": 75056,
+                                "entity-type": "item"}},}}],
+            }
+        }
+        self.item = Item(self.site, "Q90")
+
+    def test_claims_returns_all(self):
+        assert len(self.item.claims()) == 2
+
+    def test_claims_filter_by_prop_coordinates(self):
+        coords = self.item.claims(prop=["P625"])
+        assert len(coords) == 1
+        coord = coords[0].value
+        assert isinstance(coord, GlobeCoordinate)
+        assert coord.latitude == 48.86
+        assert coord.longitude == 2.35
+
+    def test_claims_filter_by_prop_item(self):
+        subdivisions = self.item.claims(prop=["P150"])
+        assert len(subdivisions) == 1
+        assert isinstance(subdivisions[0].value, Item)
+
+
+class TestWikiBaseSiteEntities(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch.object(WikiBaseSite, '__init__', lambda self, *a, **kw: None):
+            self.site = WikiBaseSite.__new__(WikiBaseSite)
+            self.site.host = "www.wikidata.org"
+        patcher = mock.patch.object(self.site, 'api', mock.MagicMock(return_value={
+            "entities": {
+                "Q42": {
+                    "type": "item",
+                    "labels": {},
+                    "descriptions": {},
+                    "sitelinks": {},
+                    "claims": {}},
+                "P238": {
+                    "type": "property",
+                    "labels": {},
+                    "descriptions": {},
+                    "sitelinks": {},
+                    "claims": {}},
+            }
+        }))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_entities_returns_mixed_items_and_properties(self):
+        entities = self.site.entities(ids=["Q42", "P238"])
+        assert len(entities) == 2
+        assert {type(e) for e in entities} == {Item, Property}
+
+    def test_item_repr(self):
+        entities = self.site.entities(ids=["Q42", "P238"])
+        item = next(e for e in entities if isinstance(e, Item))
+        assert repr(item) == "<Item object Q42 (www.wikidata.org)>"
+
+    def test_property_repr(self):
+        entities = self.site.entities(ids=["Q42", "P238"])
+        prop = next(e for e in entities if isinstance(e, Property))
+        assert repr(prop) == "<Property object P238 (www.wikidata.org)>"
+
+    def test_property_claims_filtered(self):
+        prop_site = make_mock_wikibase_site()
+        prop_site.api.return_value = {
+            "claims": {
+                "P1659": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property":
+                            "P1659",
+                            "datatype": "wikibase-property",
+                            "datavalue": {
+                                "value":{
+                                    "numeric-id": 239,
+                                    "entity-type": "property"}}}},
+                    {
+                        "mainsnak": {
+                            "snaktype":
+                            "value",
+                            "property":
+                            "P1659",
+                            "datatype": "wikibase-property",
+                            "datavalue": {
+                                "value": {
+                                    "numeric-id": 229,
+                                    "entity-type": "property"}}}},
+                ],
+            }
+        }
+        prop = Property(prop_site, "P238")
+        related = prop.claims(prop=["P1659"])
+        assert len(related) == 2
+        assert all(isinstance(c.value, Property) for c in related)
+
+
+class TestSiteWikibaseRepository(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch.object(Site, '__init__', lambda self, *a, **kw: None):
+            self.site = Site.__new__(Site)
+            self.site._wikibase_repository = None
+            self.site.connection = mock.MagicMock()
+        self.mock_api = mock.MagicMock(return_value={
+            "query": {"wikibase": {"repo": {"url": {
+                "base": "https://www.wikidata.org",
+                "scriptpath": "/w"
+            }}}}
+        })
+        patcher = mock.patch.object(self.site, 'api', self.mock_api)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @mock.patch('mwclient.client.WikiBaseSite')
+    def test_wikibase_repository_returns_wikibase_site(self, MockWikiBaseSite):
+        repo = self.site.wikibase_repository
+        MockWikiBaseSite.assert_called_once_with(
+            "www.wikidata.org", path="/w/", scheme="https", pool=self.site.connection
+        )
+        assert repo is MockWikiBaseSite.return_value
+
+    @mock.patch('mwclient.client.WikiBaseSite')
+    def test_wikibase_repository_is_cached(self, MockWikiBaseSite):
+        repo1 = self.site.wikibase_repository
+        repo2 = self.site.wikibase_repository
+        assert repo1 is repo2
+        self.mock_api.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_wikibase.py
+++ b/test/test_wikibase.py
@@ -177,10 +177,7 @@ class TestWikiBaseSiteEntities(unittest.TestCase):
 class TestSiteWikibaseRepository(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch.object(Site, '__init__', lambda self, *a, **kw: None):
-            self.site = Site.__new__(Site)
-            self.site._wikibase_repository = None
-            self.site.connection = mock.MagicMock()
+        self.site = Site('www.wikipedia.org', do_init=False, pool=mock.MagicMock())
         self.mock_api = mock.MagicMock(return_value={
             "query": {"wikibase": {"repo": {"url": {
                 "base": "https://www.wikidata.org",


### PR DESCRIPTION
I've been working on implementation of reading method of the wikibase API:
- wikibase_item() in the page module
- WikiBaseSite and entities() in the client module
- entity module. The Claim class is mainly an helper to access dictionnary returned by wbgetclaims or wbgetentities method from API

Example of how it works:

``` python
import mwclient

site = mwclient.Site(('https', 'en.wikipedia.org'))
article = site.Pages['Paris']
item = article.wikibase_item()

# wikibase repo
wikidata = site.wikibase()
print wikidata

# Claims
claims = item.claims()
for claim in claims:
    print claim
    print claim.value

# Only coordinates
for claim in item.claims(prop=['P625']):
    print "%f, %f" % (claim.latitude, claim.longitude)

# Only subdivision (Paris subdivision are Items)
for claim in item.claims(prop=['P150']):
    print claim.item

wikidata = mwclient.WikiBaseSite(('https', 'www.wikidata.org'))
entities = wikidata.entities(ids=['Q42', 'P238'])
for entity in entities:
    print entity
    if entity.entity == 'P238':
        for claim in entity.claims(prop=['P1659']):
            print claim.property_value
# <Property object P238 (('https', 'www.wikidata.org'))>
# <Property object P239 (('https', 'www.wikidata.org'))>
# <Property object P229 (('https', 'www.wikidata.org'))>
# <Item object Q42 (('https', 'www.wikidata.org'))>
```
