### PR TITLE
use 'exec' in py3-compatible manner

### DIFF
--- a/mwclient/ex.py
+++ b/mwclient/ex.py
@@ -12,7 +12,7 @@ def read_config(config_files, **predata):
 
 def _read_config_file(_config_file, predata):
     _file = open(_config_file)
-    exec _file in globals(), predata
+    exec(_file, globals(), predata)
     _file.close()
 
     for _k, _v in predata.iteritems():


### PR DESCRIPTION
per https://docs.python.org/2/reference/simple_stmts.html ,
as exec is a function not a statement in py3, the py2 version
has been set to allow the subsequent statement to be a tuple,
so we can invoke it like this to make it both py2 and py3
compatible. Without this, byte-compiling the file fails under
py3.

Disclaimer: I have no clue if this does the right thing or if `ex.py` works or does anything at all, with or without this change. I just know it stops my Fedora package build complaining. :)