### PR TITLE
add 'end' arg for PageList

### DIFF
--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -181,7 +181,7 @@ class Category(mwclient.page.Page, GeneratorList):
 
 class PageList(GeneratorList):
 
-    def __init__(self, site, prefix=None, start=None, namespace=0, redirects='all'):
+    def __init__(self, site, prefix=None, start=None, namespace=0, redirects='all', end=None):
         self.namespace = namespace
 
         kwargs = {}
@@ -189,6 +189,8 @@ class PageList(GeneratorList):
             kwargs['gapprefix'] = prefix
         if start:
             kwargs['gapfrom'] = start
+        if end:
+            kwargs['gapto'] = end
 
         GeneratorList.__init__(self, site, 'allpages', 'ap',
                                gapnamespace=text_type(namespace), gapfilterredir=redirects, **kwargs)


### PR DESCRIPTION
this is sometimes useful; for instance I have a use case for
getting all pages in a given namespace that are alphabetically
between two specific points (because their names are in a
predictable format that involves alphabetically-sorted dates).
'end' is added as the last kwarg to avoid breaking any current
uses that rely on the kwarg ordering (thanks dan for pointing
that out).