### PR TITLE
make examples python-3 compatible

### DIFF
--- a/examples/basic_edit.py
+++ b/examples/basic_edit.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
 import sys, os
+
 if len(sys.argv) > 3:
 	sys.path.append(os.path.abspath(sys.argv[3]))
 if len(sys.argv) < 3:
-	print 'python basic_edit_test.py <config> <prefix> [<include path>]'
-	print
+	print('python basic_edit_test.py <config> <prefix> [<include path>]\n')
 	sys.exit()
 
 ## Create a config file containing:
@@ -12,7 +13,6 @@ if len(sys.argv) < 3:
 # ext = '.php'
 # username = 'Bryan'
 # password = 'xyz'
-
 
 prefix = sys.argv[2]
 
@@ -24,12 +24,12 @@ except ImportError:
 site = mwclient.ex.ConfiguredSite(sys.argv[1])
 site.compress = False
 
-print 'Running configured site', sys.argv[1]
-print 'Site has writeapi:', getattr(site, 'writeapi', False)
+print('Running configured site', sys.argv[1])
+print('Site has writeapi:', getattr(site, 'writeapi', False))
 
 page = site.Pages[prefix + '/text1']
 
-print 'Editing page1'
+print('Editing page1')
 
 page.edit()
 text1 = u"""== [[Test page]] ==
@@ -41,32 +41,32 @@ page.save(text1, comment1)
 rev = page.revisions(limit = 1, prop = 'timestamp|comment|content').next()
 assert rev['comment'] == comment1, rev
 assert rev['*'] == rev['*'], rev
-print 'Page edited on', rev['timestamp']
-print 'Links:', list(page.links(generator = False))
-print 'External links:', list(page.extlinks())
+print('Page edited on', rev['timestamp'])
+print('Links:', list(page.links(generator = False)))
+print('External links:', list(page.extlinks()))
 
-print 'Uploading image'
+print('Uploading image')
 site.upload(open('test-image.png', 'rb'), prefix + '-test-image.png', 'desc', ignore = True)
-print 'Uploading image for the second time'
+print('Uploading image for the second time')
 site.upload(open('test-image.png', 'rb'), prefix + '-test-image.png', 'desc', ignore = True)
 image = site.Images[prefix + '-test-image.png']
-print 'Imageinfo:', image.imageinfo
+print('Imageinfo:', image.imageinfo)
 history = list(image.imagehistory())
-print 'History:', history
+print('History:', history)
 
 if site.writeapi:
-	print 'Deleting old version'
+	print('Deleting old version')
 	archivename = history[1]['archivename']
 	image.delete('Testing history deletion', oldimage = archivename)
-	print 'History:', list(image.imagehistory())
+	print('History:', list(image.imagehistory()))
 
 text = page.edit()
 text += u'\n[[Image:%s-test-image.png]]' % prefix
 page.save(text, 'Adding image')
-print 'Images:', list(page.images(generator = False))
+print('Images:', list(page.images(generator = False)))
 
-print 'Cleaning up'
+print('Cleaning up')
 image.delete('Cleanup')
 page.delete('Cleanup')
 
-print 'Done'
+print('Done')

--- a/examples/upload.py
+++ b/examples/upload.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from past.builtins import xrange
 import sys
 import os
 import pprint

--- a/examples/upload.py
+++ b/examples/upload.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os
 import pprint
@@ -5,9 +6,8 @@ import pprint
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../')))
 import mwclient
 
-
 if len(sys.argv) < 3:
-    print sys.argv[0], 'username', 'password', '[host=test.wikipedia.org]', '[path=/w/]'
+    print(sys.argv[0], 'username', 'password', '[host=test.wikipedia.org]', '[path=/w/]')
     sys.exit()
 if len(sys.argv) > 3:
     host = sys.argv[3]
@@ -18,23 +18,21 @@ if len(sys.argv) > 4:
 else:
     path = '/w/'
 
-
 site = mwclient.Site(host, path)
 site.login(sys.argv[1], sys.argv[2])
-
 
 import random
 name = ''.join(random.choice('abcdefghijklmnopqrstuvwxyz') for i in xrange(8)) + '.png'
 
-print 'Using http://%s%sindex.php?title=File:' % (host, path) + name
-print 'Regular upload test'
+print('Using http://%s%sindex.php?title=File:' % (host, path) + name)
+print('Regular upload test')
 
 res = site.upload(open('test-image.png', 'rb'), name, 'Regular upload test', ignore=True)
 pprint.pprint(res)
 assert res['result'] == 'Success'
 assert 'exists' not in res['warnings']
 
-print 'Overwriting; should give a warning'
+print('Overwriting; should give a warning')
 res = site.upload(open('test-image.png', 'rb'), name, 'Overwrite upload test')
 pprint.pprint(res)
 assert res['result'] == 'Warning'
@@ -42,13 +40,13 @@ assert 'exists' in res['warnings']
 
 ses = res['sessionkey']
 
-print 'Overwriting with stashed file'
+print('Overwriting with stashed file')
 res = site.upload(filename=name, filekey=ses)
 pprint.pprint(res)
 assert res['result'] == 'Warning'
 assert 'duplicate' in res['warnings']
 assert 'exists' in res['warnings']
 
-print 'Uploading empty file; error expected'
+print('Uploading empty file; error expected')
 from StringIO import StringIO
 res = site.upload(StringIO(), name, 'Empty upload test')


### PR DESCRIPTION
This clears errors detected by landscape.io:
https://landscape.io/github/mwclient/mwclient/35/messages/error

Fixes based on recommendations here: http://python-future.org/compatible_idioms.html