### PR TITLE
encourage use of GET instead of POST when possible

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -4,13 +4,7 @@ import logging
 from six import text_type
 import six
 
-import sys
-if sys.version_info[0] >= 3:
-    # Python 3 http://stackoverflow.com/a/13625238
-    from urllib.parse import quote
-else:
-    # Python 2 http://stackoverflow.com/a/1695199
-    from urllib import quote
+from six.moves.urllib.parse import quote
 
 try:
     # Python 2.7+

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -308,9 +308,9 @@ class Site(object):
             can_get = len(dataparams) < too_big
 
         if can_get:
-            return self.raw_get(script=script,data=data,files=files, retry_on_error=retry_on_error)
+            return self.raw_get(script=script, data=data, files=files, retry_on_error=retry_on_error)
         else:
-            return self.raw_post(script=script,data,data=files=files, retry_on_error=retry_on_error)
+            return self.raw_post(script=script, data=data, files=files, retry_on_error=retry_on_error)
 
     def raw_post(self, script, data, files=None, retry_on_error=True):
         """

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -305,7 +305,7 @@ class Site(object):
 
         if can_get:
             dataparams = self._encoded_data(data)
-            can_get = len(dataparams) < too_big:
+            can_get = len(dataparams) < too_big
 
         if can_get:
             return self.raw_get(script=script,data=data,files=files, retry_on_error=retry_on_error)

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -291,7 +291,7 @@ class Site(object):
 
         if files:
             # if we have files to send, go with POST
-            can_get == False
+            can_get = False
 
         # if the params become too long, we should POST
         # http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -436,7 +436,7 @@ class Site(object):
         kwargs['action'] = action
         kwargs['format'] = 'json'
         data = self._query_string(*args, **kwargs)
-        if action == 'query':
+        if action in ['query', 'ask']:
             res = self.raw_get('api', data, retry_on_error=retry_on_error)
         else:
             res = self.raw_post('api', data, retry_on_error=retry_on_error)
@@ -961,5 +961,5 @@ class Site(object):
         kwargs = {}
         if title is None:
             kwargs['title'] = title
-        result = self.raw_get('ask', query=query, **kwargs)
+        result = self.raw_api('ask', query=query, **kwargs)
         return result['query']['results']

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -266,7 +266,7 @@ class Site(object):
 
     @staticmethod
     def _encoded_data(data):
-        return '&'.join(['%s=%s' % (quote(k), quote(v)) for k, v in data.items()]
+        return '&'.join(['%s=%s' % (quote(k), quote(v)) for k, v in data.items()])
 
 
     def raw_call(self, script, data, files=None, retry_on_error=True):


### PR DESCRIPTION
Consistent with
https://github.com/mwclient/mwclient/issues/55
"Use API calls more efficiently"
and
https://github.com/mwclient/mwclient/issues/76
"Courteous API usage is promoted through code samples and smart defaults"
"Efficient usage of API calls"

This proposed pull allows mwclient to use GET instead of POST for some requests.




There are 2 major benefits.

1. Server performance. GET operations can be cached with Varnish and
similar tools, POST cannot. My site has dramatically more bot traffic than
humans, and this makes a very big difference.

This is consistent with RFC1945
https://tools.ietf.org/html/rfc1945#section-8 which explicitly states

  Applications must not cache responses to a POST request because the
   application has no way of knowing that the server would return an
   equivalent response on some future request.

So it's important that the client choose GET when caching might be possible, it cannot be a server decision once a POST has been issued.

See also http://stackoverflow.com/a/3477374



2. Logging/Diagnostics. GET params are easily visible in a standard log

118.35.162.119 - - [15/Jul/2016:03:24:58 +0000] "GET /api.php?inprop=protection&continue=&format=json&prop=info&titles=rs12229654&meta=userinfo&action=query&uiprop=blockinfo%7Chasmsg HTTP/1.1" 200 279 "-" "MwClient/0.8.2.dev1 (https://github.com/mwclient/mwclient)"

is much more useful than

118.35.162.119 - - [14/Jul/2016:16:02:12 +0000] "POST /api.php HTTP/1.1" 200 280 "-" "MwClient/0.8.2.dev1 (https://github.com/mwclient/mwclient)"

For apache, getting these sorts of details from a POST requires installing
additional modules, and is discouraged except during brief, targeted
debugging.

https://httpd.apache.org/docs/current/mod/mod_dumpio.html

A reminder that the query string is secure during https
http://stackoverflow.com/questions/323200/is-an-https-query-string-secure
and if there are certain parameters which you'd like to see protected they can be added to the logic of raw_call, so that those methods or params prefer POST, not GET.

Similarly I've chosen a logic of default to GET, but could alter this to defaulting to POST. In my experience a handful of whitelistable queries are a major source of traffic and server demand, so even a small whitelist would be beneficial.

The new raw_get method is nearly identical to the previous raw_call method, which has been renamed to raw_post. I would be happy to refactor out the common functionality, but at this stage felt that being easy to understand was more important. If that is a priority please say so, and I will further modify the code.







