### PR TITLE
cope with .ask() having more than 50 results

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -843,4 +843,9 @@ class Site(object):
         if title is None:
             kwargs['title'] = title
         result = self.raw_api('ask', query=query, **kwargs)
-        return result['query']['results']
+        for r in result['query']['results']:
+            yield r
+        while 'query-continue-offset' in result:
+            result = self.raw_api('ask', query='%s|offset=%s' % (query, result['query-continue-offset']), **kwargs)
+            for r in result['query']['results']:
+                yield r


### PR DESCRIPTION
This uses query-continue-offset to retrieve all results when ask has more than 50 responses.
https://www.semantic-mediawiki.org/wiki/Ask_API#Limit_and_offset