### PR TITLE
Support sending custom headers with all requests

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -53,7 +53,7 @@ class Site(object):
                  max_retries=25, wait_callback=lambda *x: None, clients_useragent=None,
                  max_lag=3, compress=True, force_login=True, do_init=True, httpauth=None,
                  reqs=None, consumer_token=None, consumer_secret=None, access_token=None,
-                 access_secret=None, client_certificate=None):
+                 access_secret=None, client_certificate=None, custom_headers=None):
         # Setup member variables
         self.host = host
         self.path = path
@@ -101,6 +101,8 @@ class Site(object):
                     url='https://github.com/mwclient/mwclient'
                 )
             )
+            if custom_headers:
+                self.connection.headers.update(custom_headers)
         else:
             self.connection = pool
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -156,6 +156,16 @@ class TestClient(TestCase):
         assert 'MyFabulousClient' in responses.calls[0].request.headers['user-agent']
 
     @responses.activate
+    def test_custom_headers_are_sent(self):
+        # Custom headers should be sent to the server
+
+        self.httpShouldReturn(self.metaResponseAsJson())
+
+        site = mwclient.Site('test.wikipedia.org', custom_headers={'X-Wikimedia-Debug': 'host=mw1099.eqiad.wmnet; log'})
+
+        assert 'host=mw1099.eqiad.wmnet; log' in responses.calls[0].request.headers['X-Wikimedia-Debug']
+
+    @responses.activate
     def test_basic_request(self):
 
         self.httpShouldReturn(self.metaResponseAsJson())


### PR DESCRIPTION
Allow sending custom headers (e.g. X-Wikimedia-Debug) with all requests
by passing a dict of header data in the Site constructor.
