### PR TITLE
Send parse requests via POST

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -639,7 +639,7 @@ class Site(object):
             kwargs['redirects'] = '1'
         if mobileformat:
             kwargs['mobileformat'] = '1'
-        result = self.get('parse', **kwargs)
+        result = self.post('parse', **kwargs)
         return result['parse']
 
     # def block(self): TODO?


### PR DESCRIPTION
In 1d61770 the Site.parse() command was changed from GET to POST. This
effectively limits the amount of wikitext that can be rendered to what
will fit in the URI limit of the webserver serving the MediaWiki site.
We could do something really tricky to look at the size of the text
argument and switch between GET and POST based on that, but it seems
much simpler to just stick with POST for this action.

Downstream bug: https://phabricator.wikimedia.org/T158715