### PR TITLE
Add uselang to revisions() and usercontributions()

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1029,7 +1029,7 @@ class Site(object):
         return listing.List(self, 'search', 'sr', limit=limit, **kwargs)
 
     def usercontributions(self, user, start=None, end=None, dir='older', namespace=None,
-                          prop=None, show=None, limit=None):
+                          prop=None, show=None, limit=None, uselang=None):
         """
         List the contributions made by a given user to the wiki, à la Special:Contributions.
 
@@ -1038,7 +1038,8 @@ class Site(object):
         kwargs = dict(listing.List.generate_kwargs('uc', user=user, start=start, end=end,
                                                    dir=dir, namespace=namespace,
                                                    prop=prop, show=show))
-        return listing.List(self, 'usercontribs', 'uc', limit=limit, **kwargs)
+        return listing.List(self, 'usercontribs', 'uc', limit=limit, uselang=uselang,
+                            **kwargs)
 
     def users(self, users, prop='blockinfo|groups|editcount'):
         """

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -437,7 +437,7 @@ class Page(object):
                   dir='older', user=None, excludeuser=None, limit=50,
                   prop='ids|timestamp|flags|comment|user',
                   expandtemplates=False, section=None,
-                  diffto=None, slots=None):
+                  diffto=None, slots=None, uselang=None):
         """List revisions of the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Revisions
@@ -460,6 +460,8 @@ class Page(object):
                           revision respectively.
             slots (str): The content slot (Mediawiki >= 1.32) to retrieve
                 content from.
+            uselang (str): Language to use for parsed edit comments and other
+                           localized messages.
 
         Returns:
             mwclient.listings.List: Revision iterator
@@ -475,6 +477,7 @@ class Page(object):
 
         kwargs['rvdir'] = dir
         kwargs['rvprop'] = prop
+        kwargs['uselang'] = uselang
         if expandtemplates:
             kwargs['rvexpandtemplates'] = '1'
         if section is not None:

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -261,6 +261,7 @@ class TestPageApiArgs(unittest.TestCase):
             'prop': 'revisions',
             'rvdir': 'older',
             'titles': self.page.page_title,
+            'uselang': None,
             'rvprop': 'content|timestamp',
             'rvlimit': '1',
             'rvslots': 'main',


### PR DESCRIPTION
Allow specifying `uselang` with `Page.revisions()` and `Site.usercontributions()` to get localized parsed comments with `prop=parsedcomment`.

Do we need to support `uselang` more places? I don't see a big point in localized error messages, but there could be other uses.