### PR TITLE
Fix semantic mediawiki call and login with MW > 1.27 , Issue #153 and Issue #149

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -489,13 +489,14 @@ class Site(object):
                 # If the wiki is read protected, it is not possible
                 # to get the wiki version using the API.
                 # We fallback to the old way if we fail.
-                loginkwargs = {'meta':'tokens'}
+                loginkwargs = {'meta': 'tokens'}
                 # we cannot use api() as api() is adding "userinfo" to the query
                 # and this raises an readapideniederrot if the wiki is read protected.
                 # we fallback to raw_api.
-                login=self.raw_api('query',http_method='GET',**loginkwargs)
-                try: #MW 1.27+
-                    kwargs['lgtoken']=login["tokens"]["logintoken"];
+                login = self.raw_api('query', http_method='GET', **loginkwargs)
+                # MW 1.27+
+                try:
+                    kwargs['lgtoken'] = login["tokens"]["logintoken"]
                 except : # fallback to MW < 1.27 authentication
                     pass
 

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -957,7 +957,7 @@ class Site(object):
 
         offset = 0
         while offset is not None:
-            results = self.raw_api('ask', query='{query}&parameters=offset%3D{offset}'.format(
+            results = self.raw_api('ask', query='{query}|offset={offset}'.format(
                 query=query, offset=offset), http_method='GET', **kwargs)
 
             offset = results.get('query-continue-offset')

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -957,8 +957,8 @@ class Site(object):
 
         offset = 0
         while offset is not None:
-            results = self.raw_api('ask', query='{query}|offset={offset}'.format(
-                query=query, offset=offset, http_method='GET'), **kwargs)
+            results = self.raw_api('ask', query='{query}&parameters=offset%3D{offset}'.format(
+                query=query, offset=offset), http_method='GET', **kwargs)
 
             offset = results.get('query-continue-offset')
             for result in results['query']['results']:

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -975,5 +975,5 @@ class Site(object):
                 query=query, offset=offset), http_method='GET', **kwargs)
 
             offset = results.get('query-continue-offset')
-            for result in results['query']['results']:
-                yield result
+            for key, value in results['query']['results'].iteritems():
+                yield {key:value}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -497,7 +497,7 @@ class Site(object):
                 # MW 1.27+
                 try:
                     kwargs['lgtoken'] = login["tokens"]["logintoken"]
-                except : # fallback to MW < 1.27 authentication
+                except:  # fallback to MW < 1.27 authentication
                     pass
 
                 login = self.post('login', **kwargs)
@@ -976,4 +976,4 @@ class Site(object):
 
             offset = results.get('query-continue-offset')
             for key, value in results['query']['results'].iteritems():
-                yield {key:value}
+                yield {key: value}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -484,12 +484,12 @@ class Site(object):
             }
             if self.credentials[2]:
                 kwargs['lgdomain'] = self.credentials[2]
+            # Try to login using the scheme for MW 1.27+ .
+            # If the wiki is read protected, it is not possible
+            # to get the wiki version using the API.
+            # We fallback to the old way if we fail.
+            loginkwargs = {'meta': 'tokens'}
             while True:
-                # Try to login using the scheme for MW 1.27+ .
-                # If the wiki is read protected, it is not possible
-                # to get the wiki version using the API.
-                # We fallback to the old way if we fail.
-                loginkwargs = {'meta': 'tokens'}
                 # we cannot use api() as api() is adding "userinfo" to the query
                 # and this raises an readapideniederrot if the wiki is read protected.
                 # we fallback to raw_api.


### PR DESCRIPTION
A closing parenthesis was misplaced in client.ask() : this removed the 'http_method=get' in subsequents raw_api_calls.