### PR TITLE
Fix semantic mediawiki call and login with MW > 1.27 , Issue #153 and Issue #149

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -973,7 +973,7 @@ class Site(object):
         offset = 0
         while offset is not None:
             results = self.raw_api('ask', query='{query}|offset={offset}'.format(
-                query=query, offset=offset, http_method='GET'), **kwargs)
+                query=query, offset=offset), http_method='GET', **kwargs)
 
             offset = results.get('query-continue-offset')
             for result in results['query']['results']:

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -976,5 +976,5 @@ class Site(object):
                 query=query, offset=offset), http_method='GET', **kwargs)
 
             offset = results.get('query-continue-offset')
-            for result in results['query']['results']:
-                yield result
+            for key, value in results['query']['results'].iteritems():
+                yield {key: value}


### PR DESCRIPTION
Did some rebasing of #155, but since the pull request was from the master branch I couldn't overwrite it, so I created a new PR.

Note that I modified the `get_token()` method to use `raw_api()`, so that it can be used in the `login()` method. Also fixed the tests.

Can you give it a test, @ubibene ?

I created a separate issue for the session timeout problem, #158 .