### PR TITLE
Fix Client.ask getting no results from semantic query,  Issue#161

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -999,6 +999,6 @@ class Site(object):
                     offset = results.get('query-continue-offset')
                     for key, value in six.iteritems(answer):
                         yield {key: value}
-                else:
+                else:  # query returns no results
                     offset = None
                     yield {}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -990,12 +990,15 @@ class Site(object):
         while offset is not None:
             results = self.raw_api('ask', query='{query}|offset={offset}'.format(
                 query=query, offset=offset), http_method='GET', **kwargs)
-
-            offset = results.get('query-continue-offset')
-            answer = results.get('query').get('results')
-            if (answer):
-                for key, value in six.iteritems(answer):
-                    yield {key: value}
-            else:
+            if results.get('error'):  # malformed query, maybe should raise an exception
                 offset = None
                 yield {}
+            elif results.get('query'):
+                answer = results.get('query').get('results')
+                if (answer):
+                    offset = results.get('query-continue-offset')
+                    for key, value in six.iteritems(answer):
+                        yield {key: value}
+                else:
+                    offset = None
+                    yield {}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -993,4 +993,4 @@ class Site(object):
 
             offset = results.get('query-continue-offset')
             for key, value in results['query']['results'].iteritems():
-                yield {key: value}
+                yield {key:value}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -498,12 +498,8 @@ class Site(object):
             except KeyError:
                 log.debug('Failed to get login token, MediaWiki is older than 1.27.')
 
+            loginkwargs = {'meta': 'tokens'}
             while True:
-                # Try to login using the scheme for MW 1.27+ .
-                # If the wiki is read protected, it is not possible
-                # to get the wiki version using the API.
-                # We fallback to the old way if we fail.
-                loginkwargs = {'meta': 'tokens'}
                 # we cannot use api() as api() is adding "userinfo" to the query
                 # and this raises an readapideniederrot if the wiki is read protected.
                 # we fallback to raw_api.

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -992,7 +992,7 @@ class Site(object):
             >>> query = "[[Category:my cat]]|[[Has name::a name]]|?Has property"
             >>> answer = site.ask(query)
             >>> for a in answer:
-            >>>     for key,value in a.iteritems() # or a.items() in python 3
+            >>>     for key,value in a.iteritems() # or a.items() in python 3.
             >>>         print(key)
             >>>         print(value)
         """

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -498,18 +498,7 @@ class Site(object):
             except KeyError:
                 log.debug('Failed to get login token, MediaWiki is older than 1.27.')
 
-            loginkwargs = {'meta': 'tokens'}
             while True:
-                # we cannot use api() as api() is adding "userinfo" to the query
-                # and this raises an readapideniederrot if the wiki is read protected.
-                # we fallback to raw_api.
-                login = self.raw_api('query', http_method='GET', **loginkwargs)
-                # MW 1.27+
-                try:
-                    kwargs['lgtoken'] = login["tokens"]["logintoken"]
-                except:  # fallback to MW < 1.27 authentication
-                    pass
-
                 login = self.post('login', **kwargs)
 
                 if login['login']['result'] == 'Success':

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -507,7 +507,7 @@ class Site(object):
                 # MW 1.27+
                 try:
                     kwargs['lgtoken'] = login["tokens"]["logintoken"]
-                except : # fallback to MW < 1.27 authentication
+                except:  # fallback to MW < 1.27 authentication
                     pass
 
                 login = self.post('login', **kwargs)
@@ -993,4 +993,4 @@ class Site(object):
 
             offset = results.get('query-continue-offset')
             for key, value in results['query']['results'].iteritems():
-                yield {key:value}
+                yield {key: value}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -503,13 +503,14 @@ class Site(object):
                 # If the wiki is read protected, it is not possible
                 # to get the wiki version using the API.
                 # We fallback to the old way if we fail.
-                loginkwargs = {'meta':'tokens'}
+                loginkwargs = {'meta': 'tokens'}
                 # we cannot use api() as api() is adding "userinfo" to the query
                 # and this raises an readapideniederrot if the wiki is read protected.
                 # we fallback to raw_api.
-                login=self.raw_api('query',http_method='GET',**loginkwargs)
-                try: #MW 1.27+
-                    kwargs['lgtoken']=login["tokens"]["logintoken"];
+                login = self.raw_api('query', http_method='GET', **loginkwargs)
+                # MW 1.27+
+                try:
+                    kwargs['lgtoken'] = login["tokens"]["logintoken"]
                 except : # fallback to MW < 1.27 authentication
                     pass
 

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -992,5 +992,10 @@ class Site(object):
                 query=query, offset=offset), http_method='GET', **kwargs)
 
             offset = results.get('query-continue-offset')
-            for key, value in results['query']['results'].iteritems():
-                yield {key: value}
+            answer = results.get('query').get('results')
+            if (answer):
+                for key, value in six.iteritems(answer):
+                    yield {key: value}
+            else:
+                offset = None
+                yield {}

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -980,7 +980,21 @@ class Site(object):
         API doc: https://semantic-mediawiki.org/wiki/Ask_API
 
         Returns:
-            Generator for retrieving all search results
+            Generator for retrieving all search results.
+            Iterating over the generator gives a dictionnary containing the answers
+            to the query.
+            The dictionnary is empty if either:
+               - the query is valid but there are no answers,
+               - or if the query is not valid).
+
+        Examples:
+
+            >>> query = "[[Category:my cat]]|[[Has name::a name]]|?Has property"
+            >>> answer = site.ask(query)
+            >>> for a in answer:
+            >>>     for key,value in a.iteritems() # or a.items() in python 3
+            >>>         print(k)
+            >>>         print(v)
         """
         kwargs = {}
         if title is None:

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -985,7 +985,7 @@ class Site(object):
             to the query.
             The dictionnary is empty if either:
                - the query is valid but there are no answers,
-               - or if the query is not valid).
+               - or if the query is not valid.
 
         Examples:
 
@@ -993,8 +993,8 @@ class Site(object):
             >>> answer = site.ask(query)
             >>> for a in answer:
             >>>     for key,value in a.iteritems() # or a.items() in python 3
-            >>>         print(k)
-            >>>         print(v)
+            >>>         print(key)
+            >>>         print(value)
         """
         kwargs = {}
         if title is None:

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -992,7 +992,7 @@ class Site(object):
             >>> query = "[[Category:my cat]]|[[Has name::a name]]|?Has property"
             >>> answer = site.ask(query)
             >>> for a in answer:
-            >>>     for key,value in a.iteritems() # or a.items() in python 3.
+            >>>     for key,value in a.iteritems() # or a.items() in python 3
             >>>         print(key)
             >>>         print(value)
         """

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -499,6 +499,20 @@ class Site(object):
                 log.debug('Failed to get login token, MediaWiki is older than 1.27.')
 
             while True:
+                # Try to login using the scheme for MW 1.27+ .
+                # If the wiki is read protected, it is not possible
+                # to get the wiki version using the API.
+                # We fallback to the old way if we fail.
+                loginkwargs = {'meta':'tokens'}
+                # we cannot use api() as api() is adding "userinfo" to the query
+                # and this raises an readapideniederrot if the wiki is read protected.
+                # we fallback to raw_api.
+                login=self.raw_api('query',http_method='GET',**loginkwargs)
+                try: #MW 1.27+
+                    kwargs['lgtoken']=login["tokens"]["logintoken"];
+                except : # fallback to MW < 1.27 authentication
+                    pass
+
                 login = self.post('login', **kwargs)
 
                 if login['login']['result'] == 'Success':


### PR DESCRIPTION
Check : 

```
import mwclient
import six

site=mwclient.Site(('https','sandbox.semantic-mediawiki.org'),'/w/')
query_with_results="[[Has email::+]]|?Label" 
query_with_no_results="[[Has email::xxxx]]|?Label" 

answer=site.ask(query_with_results)
empty_answer=site.ask(query_with_no_results)

print("non empty answer")
for a in answer:
    for k,v in six.iteritems(a):
        print(k)
        print(v)
print("-----------")
print("empty answer")
for a in empty_answer:
    for k,v in six.iteritems(a):
        print(k)
        print(v)
print("-----------")
```

Output:
```
non empty answer
Issue/2093/1# 429eac66925d6bdd9dfecad0fc7e7ce7
{u'fulltext': u'Issue/2093/1# 429eac66925d6bdd9dfecad0fc7e7ce7', u'displaytitle': u'', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': []}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Issue/2093/1#_429eac66925d6bdd9dfecad0fc7e7ce7'}
Lorem ipsum Export
{u'fulltext': u'Lorem ipsum Export', u'displaytitle': u'', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': []}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Lorem_ipsum_Export'}
Issue/2093/1
{u'fulltext': u'Issue/2093/1', u'displaytitle': u'', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': []}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Issue/2093/1'}
Issue/1855 (Lorem ipsum)
{u'fulltext': u'Issue/1855 (Lorem ipsum)', u'displaytitle': u'Lorem ipsum', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': []}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Issue/1855_(Lorem_ipsum)'}
Lorem ipsum# 0a872dd5b2e992230eac6aa27ffc0174
{u'fulltext': u'Lorem ipsum# 0a872dd5b2e992230eac6aa27ffc0174', u'displaytitle': u'', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': []}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Lorem_ipsum#_0a872dd5b2e992230eac6aa27ffc0174'}
Azure
{u'fulltext': u'Azure', u'displaytitle': u'', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': [{u'displaytitle': u'', u'fulltext': u'Azure', u'namespace': 0, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Azure', u'exists': u'1'}]}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Azure'}
Lorem ipsum
{u'fulltext': u'Lorem ipsum', u'displaytitle': u'', u'exists': u'1', u'namespace': 0, u'printouts': {u'Label': []}, u'fullurl': u'https://sandbox.semantic-mediawiki.org/wiki/Lorem_ipsum'}
-----------
empty answer
-----------
```

More over I replaced x.itermitems() by six.iteritems(x) for Python 2.7/3.x compatibilty
