### PR TITLE
detect, warn and retry on nonce error

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -307,6 +307,13 @@ class Site(object):
                 sleeper.sleep()
                 return False
 
+            # should the above dict instead be a list?
+            if (info['error'].get('code') == u'mwoauth-invalid-authorization' and
+                'Nonce already used' in info['error'].get('info')):
+                log.warning('retrying due to nonce error https://phabricator.wikimedia.org/T106066')
+                sleeper.sleep()
+                return False
+
             if 'query' in info['error']:
                 # Semantic Mediawiki does not follow the standard error format
                 raise errors.APIError(None, info['error']['query'], kwargs)

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -307,9 +307,9 @@ class Site(object):
                 sleeper.sleep()
                 return False
 
-            # should the above dict instead be a list?
+            # cope with https://phabricator.wikimedia.org/T106066
             if (info['error'].get('code') == u'mwoauth-invalid-authorization' and
-                'Nonce already used' in info['error'].get('info')):
+               'Nonce already used' in info['error'].get('info')):
                 log.warning('retrying due to nonce error https://phabricator.wikimedia.org/T106066')
                 sleeper.sleep()
                 return False


### PR DESCRIPTION
retry on redis/memcached connection error, which looks like a nonce reuse

https://phabricator.wikimedia.org/T106066
indicates that while the text of the error message is perhaps poor (in that it should propagate or better communicate the upstream error from memcached or redis), but that fundamentally this is not something that the mediawiki folks seem inclined to change on the server side.

https://phabricator.wikimedia.org/T109173
indicates that the error is well known to the pywikibot code, and that they've addressed it via
https://gerrit.wikimedia.org/r/#/c/289582/