### PR TITLE
Making sure to catch APIError on failed legacy login (#166)

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -507,7 +507,7 @@ class Site(object):
             # have to try. If the attempt fails, we try the old method.
             try:
                 kwargs['lgtoken'] = self.get_token('login')
-            except KeyError:
+            except (errors.APIError, KeyError):
                 log.debug('Failed to get login token, MediaWiki is older than 1.27.')
 
             while True:

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name='mwclient',
       license='MIT',
       packages=['mwclient'],
       cmdclass={'test': PyTest},
-      tests_require=['pytest-pep8', 'pytest-cache', 'pytest', 'pytest-cov', 'responses>=0.3.0', 'mock'],
+      tests_require=['pytest-pep8', 'pytest-cache', 'pytest', 'pytest-cov', 'responses<0.6', 'mock'],
       install_requires=requirements,
       zip_safe=True
       )


### PR DESCRIPTION
When mwclient attempts to login with an older version of mediawiki, it throws an APIError(readapidenied) from the first failed login, but it fails to catch this typed error and never tries the code with the older MW login mechanism. See #166