### PR TITLE
using OrderedDict as object_pairs_hook (#170)

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -415,7 +415,7 @@ class Site(object):
                             http_method=http_method)
 
         try:
-            return json.loads(res)
+            return json.loads(res, object_pairs_hook=OrderedDict)
         except ValueError:
             if res.startswith('MediaWiki API is not enabled for this site.'):
                 raise errors.APIDisabledError


### PR DESCRIPTION
This allows the order of JSON results returned by the api to be preserved. This is important at least for the SMW api, where you can provide ordering criteria in your query. See #170. 