### PR TITLE
README: use SVG version of the logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 
-.. figure:: docs/source/logo.png
+.. figure:: docs/source/logo.svg
    :alt: Logo
    :align: center
+   :width: 270px
 
 mwclient
 ========


### PR DESCRIPTION
See https://github.com/github/markup/issues/556 for more details.

The rendering is [not entirely correct](https://github.com/github/markup/issues/556#issuecomment-326223588), so don't merge yet, but it [should work soon](https://github.com/github/markup/issues/556#issuecomment-326466252).