### PR TITLE
BC: Simplify SMW ask output structure

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1113,6 +1113,13 @@ class Site(object):
                 query=query, offset=offset), http_method='GET', **kwargs)
             self.handle_api_result(results)  # raises APIError on error
             offset = results.get('query-continue-offset')
-            answers = results['query'].get('results') or {}
-            for key, value in answers.items():
-                yield {key: value}
+            answers = results['query'].get('results', [])
+
+            if isinstance(answers, dict):
+                # In older versions of Semantic MediaWiki (at least until 2.3.0)
+                # a list was returned. In newer versions an object is returned
+                # with the page title as key.
+                answers = [answer for answer in answers.values()]
+
+            for answer in answers:
+                yield answer

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -310,6 +310,90 @@ class TestClient(TestCase):
         assert len(responses.calls) == 1
 
     @responses.activate
+    def test_smw_response_v0_5(self):
+        # Test that the old SMW results format is handled
+
+        site = self.stdSetup()
+        self.httpShouldReturn(json.dumps({
+            "query": {
+                "results": [
+                    {
+                        "exists": "",
+                        "fulltext": "Indeks (bibliotekfag)",
+                        "fullurl": "http://example.com/wiki/Indeks_(bibliotekfag)",
+                        "namespace": 0,
+                        "printouts": [
+                            {
+                                "0": "1508611329",
+                                "label": "Endringsdato"
+                            }
+                        ]
+                    },
+                    {
+                        "exists": "",
+                        "fulltext": "Serendipitet",
+                        "fullurl": "http://example.com/wiki/Serendipitet",
+                        "namespace": 0,
+                        "printouts": [
+                            {
+                                "0": "1508611394",
+                                "label": "Endringsdato"
+                            }
+                        ]
+                    }
+                ],
+                "serializer": "SMW\\Serializers\\QueryResultSerializer",
+                "version": 0.5
+            }
+        }), method='GET')
+
+        answers = set(result['fulltext'] for result in site.ask('test'))
+
+        assert answers == set(('Serendipitet', 'Indeks (bibliotekfag)'))
+
+    @responses.activate
+    def test_smw_response_v2(self):
+        # Test that the new SMW results format is handled
+
+        site = self.stdSetup()
+        self.httpShouldReturn(json.dumps({
+            "query": {
+                "results": {
+                    "Indeks (bibliotekfag)": {
+                        "exists": "1",
+                        "fulltext": "Indeks (bibliotekfag)",
+                        "fullurl": "http://example.com/wiki/Indeks_(bibliotekfag)",
+                        "namespace": 0,
+                        "printouts": {
+                            "Endringsdato": [{
+                                "raw": "1/2017/10/17/22/50/4/0",
+                                "label": "Endringsdato"
+                            }]
+                        }
+                    },
+                    "Serendipitet": {
+                        "exists": "1",
+                        "fulltext": "Serendipitet",
+                        "fullurl": "http://example.com/wiki/Serendipitet",
+                        "namespace": 0,
+                        "printouts": {
+                            "Endringsdato": [{
+                                "raw": "1/2017/10/17/22/50/4/0",
+                                "label": "Endringsdato"
+                            }]
+                        }
+                    }
+                },
+                "serializer": "SMW\\Serializers\\QueryResultSerializer",
+                "version": 2
+            }
+        }), method='GET')
+
+        answers = set(result['fulltext'] for result in site.ask('test'))
+
+        assert answers == set(('Serendipitet', 'Indeks (bibliotekfag)'))
+
+    @responses.activate
     def test_repr(self):
         # Test repr()
 


### PR DESCRIPTION
I don't really understand why the `ask()` method yields key-value pairs (`yield {key: value}`) rather than just the values (`yield value`). Since they are yielded from a generator, the keys cannot be used for indexing, so I wonder if this was just a mistake, and I'm tempted to simplify it to yield just the values (result objects), but this will be a breaking change. Do you have any opinions on this, @ubibene ?

As I was querying a site with SMW 2.3.0 I also learned that the format of the results changed either in SMW 2.4.0 or 2.5.0, so I'm adding a check to support both the old format and the new.