### PR TITLE
Revert "Fix test compat with responses@0.6.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(name='mwclient',
       install_requires=['requests_oauthlib', 'six'],
       setup_requires=['pytest-runner'],
       tests_require=['pytest', 'pytest-pep8', 'pytest-cache', 'pytest-cov',
-                     'responses>=0.6.0', 'mock'],
+                     'responses>=0.3.0', 'responses!=0.6.0', 'mock'],
       zip_safe=True
       )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,7 +52,7 @@ class TestCase(unittest.TestCase):
             responses.add_callback(mock, url, callback=callback)
         else:
             responses.add(mock, url, body=body, content_type='application/json',
-                          headers=headers, status=status)
+                          adding_headers=headers, status=status)
 
     def stdSetup(self):
         self.httpShouldReturn(self.metaResponseAsJson())


### PR DESCRIPTION
This reverts commit 1650e0e77d370ff5d7b089b60353854d548fb0a1.
Upstream restored handling of the adding_headers arg in 0.6.1.
Going back to using that name means we're still compatible with
any version of responses after 0.3.0, except 0.6.0. Also adjust
setup.py to express this correctly.