### PR TITLE
setup.py: require pytest-runner only when necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ from setuptools import setup
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 
+needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
 setup(name='mwclient',
       version='0.8.6',  # Use bumpversion to update
       description='MediaWiki API client',
@@ -27,7 +30,7 @@ setup(name='mwclient',
       license='MIT',
       packages=['mwclient'],
       install_requires=['requests_oauthlib', 'six'],
-      setup_requires=['pytest-runner'],
+      setup_requires=pytest_runner,
       tests_require=['pytest', 'pytest-pep8', 'pytest-cache', 'pytest-cov',
                      'responses>=0.3.0', 'responses!=0.6.0', 'mock'],
       zip_safe=True


### PR DESCRIPTION
This optimizes setup.py for cases when pytest-runner is not needed,
using the approach that is suggested upstream:

https://pypi.python.org/pypi/pytest-runner#conditional-requirement