### PR TITLE
[#189] Add chunked file uploads

### DIFF
--- a/mwclient/util.py
+++ b/mwclient/util.py
@@ -1,7 +1,16 @@
 import time
+import io
 
 
 def parse_timestamp(t):
     if t is None or t == '0000-00-00T00:00:00Z':
         return (0, 0, 0, 0, 0, 0, 0, 0, 0)
     return time.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
+
+
+def read_in_chunks(stream, chunk_size):
+    while True:
+        data = stream.read(chunk_size)
+        if not data:
+            break
+        yield io.BytesIO(data)


### PR DESCRIPTION
Use chunked file uploading for files larger than 1 MB as long as we’re on MediaWiki >= 1.20.

Any issues you can think of with this?