### PR TITLE
Make util.parse_timestamp() always return a time.struct_time() object.

### DIFF
--- a/mwclient/util.py
+++ b/mwclient/util.py
@@ -3,6 +3,14 @@ import io
 
 
 def parse_timestamp(t):
+    """Parses a string containing a timestamp.
+
+    Args:
+        t (str): A string containing a timestamp.
+
+    Returns:
+        time.struct_time: A timestamp.
+    """
     if t is None or t == '0000-00-00T00:00:00Z':
         return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0))
     return time.strptime(t, '%Y-%m-%dT%H:%M:%SZ')

--- a/mwclient/util.py
+++ b/mwclient/util.py
@@ -4,7 +4,7 @@ import io
 
 def parse_timestamp(t):
     if t is None or t == '0000-00-00T00:00:00Z':
-        return (0, 0, 0, 0, 0, 0, 0, 0, 0)
+        return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0))
     return time.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -13,11 +13,14 @@ if __name__ == "__main__":
 
 class TestUtil(unittest.TestCase):
 
+    def test_parse_missing_timestamp(self):
+        assert time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0)) == parse_timestamp(None)
+
     def test_parse_empty_timestamp(self):
-        assert (0, 0, 0, 0, 0, 0, 0, 0, 0) == parse_timestamp('0000-00-00T00:00:00Z')
+        assert time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0)) == parse_timestamp('0000-00-00T00:00:00Z')
 
     def test_parse_nonempty_timestamp(self):
-        assert time.struct_time([2015, 1, 2, 20, 18, 36, 4, 2, -1]) == parse_timestamp('2015-01-02T20:18:36Z')
+        assert time.struct_time((2015, 1, 2, 20, 18, 36, 4, 2, -1)) == parse_timestamp('2015-01-02T20:18:36Z')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
New pull request since I couldn't reopen #216