### PR TITLE
Remove one more stray reference to pep8

### DIFF
--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -46,7 +46,7 @@ and run pytest directly:
 
 .. code:: bash
 
-    $ pip install pytest pytest-pep8 responses
+    $ pip install pytest flake8 responses
     $ pip install -e .
     $ py.test
 


### PR DESCRIPTION
We switched to pycodestyle then flake8 recently, but one stray
reference to pep8 was left in this doc file.

Signed-off-by: Adam Williamson <awilliam@redhat.com>