### PR TITLE
tox.ini: restore commands line, fix tabs vs. spaces (#224)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ envlist = py27,py34,py35,py36,flake
 
 [testenv]
 deps =
-	pytest
+    pytest
     pytest-cov
     responses
     mock
+commands = py.test -v --cov mwclient test
 
 [testenv:flake]
 deps =
     flake8
 commands =
-	flake8 mwclient
+    flake8 mwclient


### PR DESCRIPTION
The `commands` line was accidentally(?) removed entirely in
57f716e, so tox no longer actually ran any tests (only flake8).
This restores it, with the codestyle bit removed obviously. It
also fixes two lines where a tab was used instead of spaces.

Signed-off-by: Adam Williamson <awilliam@redhat.com>