### PR TITLE
Expanding the .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ indent_size = tab
 indent_style = tab
 
 [*.py]
-max_line_length = 88
+max_line_length = 90
 
 [*.{yaml, yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,22 @@
+# top-most .editorconfig file
+root = true
+
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = space
 indent_size = 4
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.cfg]
+indent_size = tab
+
+[{make.bat, Makefile}]
+indent_style = tab
+
+[*.py]
+max_line_length = 88
+
+[*.{yaml, yml}]
+indent_size = 2


### PR DESCRIPTION
- Set the top level `.editorconfig` file as the root (good practice).

A bunch of rules to match the existing conditions:
- Indent `.cfg`, as well as `Makefile`s using tabs instead of spaces.
- Set an indent-size of 2 instead of 4 for `.yml` and `.yaml` files.
- Set a max line length of **90** (non standard) for Python files, as this seems to best match the existing code-base, though some changes will be necessary to make it fully compliant. Alternatively I'd like to suggest a max line length of either 79 (pep8) or just going up to something like 100 or even 120 characters.