### PR TITLE
Add append/prepend setting in save & use this to add touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.egg-info
 .eggs
 .tox
+.idea/*

--- a/docs/source/user/page-ops.rst
+++ b/docs/source/user/page-ops.rst
@@ -28,7 +28,7 @@ page, use `page.exists`:
 
 Edit the text as you like before saving it back to the wiki:
 
-    >>> page.save(text, 'Edit summary')
+    >>> page.edit(text, 'Edit summary')
 
 If the page didn't exist, this operation will create it.
 

--- a/examples/basic_edit.py
+++ b/examples/basic_edit.py
@@ -60,12 +60,12 @@ if site.writeapi:
     image.delete('Testing history deletion', oldimage=archivename)
     print('History:', list(image.imagehistory()))
 
-text = page.edit()
+text = page.text()
 text += u'\n[[Image:%s-test-image.png]]' % prefix
-page.save(text, 'Adding image')
+page.edit(text, 'Adding image')
 print('Images:', list(page.images(generator=False)))
-
 print('Cleaning up')
+
 image.delete('Cleanup')
 page.delete('Cleanup')
 

--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -112,3 +112,13 @@ class InvalidResponse(MwClientError):
 
 class InvalidPageTitle(MwClientError):
     pass
+
+
+class InvalidParameter(MwClientError):
+    
+    def __init__(self, param, value):
+        self.param = param
+        self.value = value
+    
+    def __str__(self):
+        return '{} is not a valid value for {}'.format(self.value, self.param)

--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -112,13 +112,3 @@ class InvalidResponse(MwClientError):
 
 class InvalidPageTitle(MwClientError):
     pass
-
-
-class InvalidParameter(MwClientError):
-    
-    def __init__(self, param, value):
-        self.param = param
-        self.value = value
-    
-    def __str__(self):
-        return '{} is not a valid value for {}'.format(self.value, self.param)

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -113,7 +113,7 @@ class Page(object):
             True
 
         """
-        level = self.protection.get(action, (action, ))[0]
+        level = self.protection.get(action, (action,))[0]
         if level == 'sysop':
             level = 'editprotected'
 
@@ -181,13 +181,13 @@ class Page(object):
         return self._edit(summary, minor, bot, section, text=text, **kwargs)
 
     def append(self, text, summary=u'', minor=False, bot=True, section=None,
-                    **kwargs):
+               **kwargs):
         """Append text to the text of a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, appendtext=text, **kwargs)
 
     def prepend(self, text, summary=u'', minor=False, bot=True, section=None,
-                     **kwargs):
+                **kwargs):
         """Prepend text to the text of a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, prependtext=text, **kwargs)
@@ -225,10 +225,11 @@ class Page(object):
         def do_edit():
             result = self.site.post('edit', title=self.name, summary=summary,
                                     token=self.get_token('edit'),
-                                        **data)
+                                    **data)
             if result['edit'].get('result').lower() == 'failure':
                 raise mwclient.errors.EditError(self, result['edit'])
             return result
+
         try:
             result = do_edit()
         except mwclient.errors.APIError as e:

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -182,13 +182,13 @@ class Page(object):
 
     def append(self, text, summary=u'', minor=False, bot=True, section=None,
                **kwargs):
-        """Append text to the text of a section or the whole page by performing an edit operation.
+        """Append text to a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, appendtext=text, **kwargs)
 
     def prepend(self, text, summary=u'', minor=False, bot=True, section=None,
                 **kwargs):
-        """Prepend text to the text of a section or the whole page by performing an edit operation.
+        """Prepend text to a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, prependtext=text, **kwargs)
 

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -215,7 +215,7 @@ class TestPage(unittest.TestCase):
         # For now, mwclient will just raise an EditError.
         # <https://github.com/mwclient/mwclient/issues/33>
         with pytest.raises(mwclient.errors.EditError):
-            page.save('Some text')
+            page.edit('Some text')
 
 
 class TestPageApiArgs(unittest.TestCase):
@@ -303,7 +303,7 @@ class TestPageApiArgs(unittest.TestCase):
         self.site.api.return_value = {
             'edit': {'result': 'Ok'}
         }
-        self.page.save('Some text')
+        self.page.edit('Some text')
         args = self.get_last_api_call_args()
 
         assert args['assert'] == 'user'
@@ -318,7 +318,7 @@ class TestPageApiArgs(unittest.TestCase):
         self.site.api.return_value = {
             'edit': {'result': 'Ok'}
         }
-        self.page.save('Some text')
+        self.page.edit('Some text')
         args = self.get_last_api_call_args()
 
         assert 'assert' not in args


### PR DESCRIPTION
Add support for using appendtext or prependtext instead of text in an api edit request. This also allows a graceful way to blank/null edit a page without having to spend two api queries to get the text and then save, so add page.touch() as well using this.