### PR TITLE
doc: Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,7 @@ Quickstart
 
 .. code-block:: python
 
-    >>> site = mwclient.Site(('https', 'en.wikipedia.org'))
+    >>> site = mwclient.Site('en.wikipedia.org')
     >>> page = site.pages[u'Leipäjuusto']
     >>> page.text()
     u'{{Unreferenced|date=September 2009}}\n[[Image:Leip\xe4juusto cheese with cloudberry jam.jpg|thumb|Leip\xe4juusto with [[cloudberry]] jam]]\n\'\'\'Leip\xe4juusto\'\'\' (bread cheese) or \'\'juustoleip\xe4\'\', which is also known in English as \'\'\'Finnish squeaky cheese\'\'\', is a fresh [[cheese]] traditionally made from cow\'s [[beestings]], rich milk from a cow that has recently calved.'

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -14,7 +14,7 @@ Then try to connect to a site:
 By default, mwclient will connect using https. If your site doesn't support
 https, you need to explicitly request http like so:
 
-    >>> site = Site(('http', 'test.wikipedia.org'))
+    >>> site = Site('test.wikipedia.org', scheme='http')
 
 .. _endpoint:
 


### PR DESCRIPTION
This fixes the warning:

```
DeprecationWarning: Specifying host as a tuple is deprecated as of mwclient 0.10.0. Please use the new scheme argument instead.