### PR TITLE
Update regarding mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(name='mwclient',
       packages=['mwclient'],
       install_requires=['requests-oauthlib', 'six'],
       setup_requires=pytest_runner,
-      tests_require=['pytest', 'pytest-cov', 'mock',
+      tests_require=['pytest', 'pytest-cov',
+                     'mock;python_version<"3.3"',
                      'responses>=0.3.0', 'responses!=0.6.0'],
       zip_safe=True
       )

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -9,9 +9,13 @@ import logging
 import requests
 import responses
 import pkg_resources  # part of setuptools
-import mock
 import time
 from requests_oauthlib import OAuth1
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 
 try:
     import json

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -6,9 +6,13 @@ import pytest
 import logging
 import requests
 import responses
-import mock
 import mwclient
 from mwclient.listing import List, GeneratorList
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 
 try:
     import json

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -6,12 +6,16 @@ import pytest
 import logging
 import requests
 import responses
-import mock
 import mwclient
 from mwclient.page import Page
 from mwclient.client import Site
 from mwclient.listing import Category
 from mwclient.errors import APIError, AssertUserFailedError, ProtectedPageError, InvalidPageTitle
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 
 try:
     import json

--- a/test/test_sleep.py
+++ b/test/test_sleep.py
@@ -2,11 +2,15 @@
 from __future__ import print_function
 import unittest
 import time
-import mock
 import pytest
 from mwclient.sleep import Sleepers
 from mwclient.sleep import Sleeper
 from mwclient.errors import MaximumRetriesExceeded
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 
 if __name__ == "__main__":
     print()


### PR DESCRIPTION
mock was included in unittest in python 3.3 unittest.mock
It is backported in PyPi so it should work either way up to python 3.6, altough i prefer the built-in.

The test files was tested with python 3.7 and 3.8 and the try, except worked. The setup.py file is not tested.