### PR TITLE
remove: py34 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 mwclient is a lightweight Python client library to the
 [MediaWiki API](https://mediawiki.org/wiki/API)
 which provides access to most API functionality.
-It works with Python 2.7 as well as 3.4 and above,
+It works with Python 2.7 as well as 3.5 and above,
 and supports MediaWiki 1.16 and above.
 For functions not available in the current MediaWiki,
 a `MediaWikiVersionError` is raised.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38,flake
+envlist = py27,py35,py36,py37,py38,flake
 
 [testenv]
 deps =


### PR DESCRIPTION
Support for Python 3.4 is stated in multiple places and already tested by the tox.ini