### PR TITLE
remove: simplejson dependency

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -6,10 +6,7 @@ import six
 
 from collections import OrderedDict
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+import json
 import requests
 from requests.auth import HTTPBasicAuth, AuthBase
 from requests_oauthlib import OAuth1

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -11,12 +11,10 @@ import responses
 import pkg_resources  # part of setuptools
 import mock
 import time
+import json
 from requests_oauthlib import OAuth1
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+
 
 if __name__ == "__main__":
     print()

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -7,13 +7,11 @@ import logging
 import requests
 import responses
 import mock
+import json
 import mwclient
 from mwclient.listing import List, GeneratorList
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+
 
 if __name__ == "__main__":
     print()

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -7,16 +7,13 @@ import logging
 import requests
 import responses
 import mock
+import json
 import mwclient
 from mwclient.page import Page
 from mwclient.client import Site
 from mwclient.listing import Category
 from mwclient.errors import APIError, AssertUserFailedError, ProtectedPageError, InvalidPageTitle
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 if __name__ == "__main__":
     print()


### PR DESCRIPTION
This library currently uses `simplejson` instead of `json` conditionally in multiple places. Presumably, this was done for compatibility with Python versions prior to 2.6, when `json` was added to the standard library. As this library only supports 2.7+, this should not be needed anymore.