### PR TITLE
remove custom null handler

### DIFF
--- a/mwclient/__init__.py
+++ b/mwclient/__init__.py
@@ -31,12 +31,4 @@ import warnings
 # Show DeprecationWarning
 warnings.simplefilter('always', DeprecationWarning)
 
-# Logging: Add a null handler to avoid "No handler found" warnings.
-try:
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
Not required as `logging.NullHandler` is available on all supported python versions. See [here](https://docs.python.org/2/library/logging.handlers.html#nullhandler) and [here](https://docs.python.org/3/library/logging.handlers.html#nullhandler).