### PR TITLE
Pass status_code to MaximumRetriesExceeded if possible

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -409,7 +409,7 @@ class Site(object):
                                 'Retrying in a moment.'
                                 .format(status=stream.status_code,
                                         text=stream.text))
-                    sleeper.sleep()
+                    sleeper.sleep(status_code=stream.status_code)
 
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
                 # In the event of a network problem

--- a/mwclient/sleep.py
+++ b/mwclient/sleep.py
@@ -72,6 +72,7 @@ class Sleeper(object):
         with the number of retries.
         Args:
             min_time (int): The minimum sleeping time.
+            status_code (int): Status code of the original exception.
         Raises:
             MaximumRetriesExceeded: If the number of retries exceeds the maximum.
         """

--- a/mwclient/sleep.py
+++ b/mwclient/sleep.py
@@ -66,7 +66,7 @@ class Sleeper(object):
         self.retry_timeout = retry_timeout
         self.callback = callback
 
-    def sleep(self, min_time=0):
+    def sleep(self, min_time=0, status_code=None):
         """
         Sleeps for a minimum of `min_time` seconds. The actual sleeping time will increase
         with the number of retries.
@@ -77,7 +77,7 @@ class Sleeper(object):
         """
         self.retries += 1
         if self.retries > self.max_retries:
-            raise MaximumRetriesExceeded(self, self.args)
+            raise MaximumRetriesExceeded(self, self.args, status_code)
 
         self.callback(self, self.retries, self.args)
 


### PR DESCRIPTION
if an API request fails and the sleeper exceeds the maximum number of retries, the exception raised doesn't contain any info about the original exception, add the status code when possible