### PR TITLE
Add gh-actions section to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,16 @@
 [tox]
 envlist = py27,py35,py36,py37,py38,py39,py310,py311,py312,flake
 
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311, flake
+    3.12: py312
+
 [testenv]
 deps =
     pytest


### PR DESCRIPTION
This is a missing bit of the CI enablement, per
https://github.com/ymyzk/tox-gh-actions . I hope this will make the Python 3.6 tests run properly.

Signed-off-by: Adam Williamson <awilliam@redhat.com>