### PR TITLE
Handle page protection having no expiry (#290)

### DIFF
--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -53,7 +53,7 @@ class Page(object):
         self.exists = 'missing' not in info
         self.length = info.get('length')
         self.protection = {
-            i['type']: (i['level'], i['expiry'])
+            i['type']: (i['level'], i.get('expiry'))
             for i in info.get('protection', ())
             if i
         }

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -165,6 +165,12 @@ class TestPage(unittest.TestCase):
         assert page.can('edit') is True  # User has 'autoconfirmed'  right
         assert page.can('move') is True  # User has 'sysop' right
 
+        # check an unusual case: no 'expiry' key, see
+        # https://github.com/mwclient/mwclient/issues/290
+        del mock_site.get.return_value['query']['pages']['728']['protection'][0]['expiry']
+        page = Page(mock_site, title)
+        assert page.protection == {'edit': ('autoconfirmed', None), 'move': ('sysop', 'infinity')}
+
     @mock.patch('mwclient.client.Site')
     def test_redirect(self, mock_site):
         # Check that page.redirect is set correctly


### PR DESCRIPTION
Issue #290 gives an example of a wiki with protected pages whose protection definitions have no 'expiry' key at all. This seems strange and, on a quick through the mediawiki code, difficult to achieve, but since there's a live site out there that does it, and mediawiki *does* seem to have at least some code to handle such cases (e.g. how the expiry shows as 'indefinite' in the page information), let's handle it too, by representing this as None.