### PR TITLE
Mark tests as requiring setuptools in tox.ini and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(name='mwclient',
       setup_requires=pytest_runner,
       tests_require=['pytest', 'pytest-cov',
                      'mock;python_version<"3.3"',
-                     'responses>=0.3.0', 'responses!=0.6.0'],
+                     'responses>=0.3.0', 'responses!=0.6.0', 'setuptools'],
       zip_safe=True
       )

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     pytest
     pytest-cov
     responses
+    setuptools
     mock
 commands = py.test -v --cov mwclient test
 


### PR DESCRIPTION
test_client.py uses pkg_resources. That's part of setuptools, not Python. Per
https://docs.python.org/3.12/whatsnew/3.12.html#removed , it was previously included by default in venv environments, but no longer is from 3.12 onwards, so we need to explicitly require setuptools to ensure it's available.