### PR TITLE
Do not append custom name to API

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -140,7 +140,7 @@ class Site(object):
 
             # Set User-Agent header field
             if clients_useragent:
-                ua = clients_useragent + ' ' + USER_AGENT
+                ua = clients_useragent
             else:
                 ua = USER_AGENT
             self.connection.headers['User-Agent'] = ua


### PR DESCRIPTION
This prevents usage from Wikis that check users' APIs in a way. CloudFlare is an example.