### PR TITLE
Add .readthedocs.yaml configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.2.5
+sphinx_rtd_theme==1.3.0


### PR DESCRIPTION
Read the Docs has started requiring a .readthedocs.yaml configuration file to be present in the repository in order to build the documentation.

https://blog.readthedocs.com/migrate-configuration-v2/

According to the timeline we have until 2023-09-25 to migrate to the new configuration file, but we've already had some builds fail during their 48-hour brownout on 2023-09-04.