### PR TITLE
HTTP basic auth: encode username and password as UTF-8 (#315)

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -181,6 +181,15 @@ class TestClient(TestCase):
         assert isinstance(site.connection.auth, requests.auth.HTTPBasicAuth)
 
     @responses.activate
+    def test_basic_auth_non_latin(self):
+
+        self.httpShouldReturn(self.metaResponseAsJson())
+
+        site = mwclient.Site('test.wikipedia.org', httpauth=('我', '非常秘密'))
+
+        assert isinstance(site.connection.auth, requests.auth.HTTPBasicAuth)
+
+    @responses.activate
     def test_httpauth_raise_error_on_invalid_type(self):
 
         self.httpShouldReturn(self.metaResponseAsJson())


### PR DESCRIPTION
As discussed upstream in
https://github.com/psf/requests/issues/4564 , HTTP basic auth usernames and passwords sent to requests as Python text strings are encoded as latin1. This of course makes it impossible to log in with a username or password containing characters not represented in latin1, as the reporter of #315 found out.

To work around this rather old-fashioned default, let's intercept string usernames and passwords and encode them as utf-8 before sending them to requests.

Anyone dealing with a really old server that can't handle utf-8, or something like that, can encode the username and password appropriately and provide them as bytestrings.