### PR TITLE
Update GHA config for Python 3.12 final

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-alpha - 3.12.0"
+          - "3.12"
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-20.04"


### PR DESCRIPTION
I think we can just do this now Python 3.12 is stable.