### PR TITLE
README updates: credit authors/maintainers, update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <h1>mwclient</h1>
 </div>
 
-[![Build status][build-status-img]](https://travis-ci.org/mwclient/mwclient)
+[![Build status][build-status-img]](https://github.com/mwclient/mwclient)
 [![Test coverage][test-coverage-img]](https://coveralls.io/r/mwclient/mwclient)
 [![Latest version][latest-version-img]](https://pypi.python.org/pypi/mwclient)
 [![MIT license][mit-license-img]](http://opensource.org/licenses/MIT)
@@ -12,7 +12,7 @@
 [![Gitter chat][gitter-chat-img]](https://gitter.im/mwclient/mwclient)
 
 
-[build-status-img]: https://img.shields.io/travis/mwclient/mwclient.svg
+[build-status-img]: https://github.com/mwclient/mwclient/actions/workflows/tox.yml/badge.svg
 [test-coverage-img]: https://img.shields.io/coveralls/mwclient/mwclient.svg
 [latest-version-img]: https://img.shields.io/pypi/v/mwclient.svg
 [mit-license-img]: https://img.shields.io/github/license/mwclient/mwclient.svg

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Latest version][latest-version-img]](https://pypi.python.org/pypi/mwclient)
 [![MIT license][mit-license-img]](http://opensource.org/licenses/MIT)
 [![Documentation status][documentation-status-img]](http://mwclient.readthedocs.io/en/latest/)
-[![Issue statistics][issue-statistics-img]](http://isitmaintained.com/project/tldr-pages/tldr)
+[![Issue statistics][issue-statistics-img]](http://isitmaintained.com/project/mwclient/mwclient)
 [![Gitter chat][gitter-chat-img]](https://gitter.im/mwclient/mwclient)
 
 
@@ -17,7 +17,7 @@
 [latest-version-img]: https://img.shields.io/pypi/v/mwclient.svg
 [mit-license-img]: https://img.shields.io/github/license/mwclient/mwclient.svg
 [documentation-status-img]: https://readthedocs.org/projects/mwclient/badge/
-[issue-statistics-img]: http://isitmaintained.com/badge/resolution/tldr-pages/tldr.svg
+[issue-statistics-img]: http://isitmaintained.com/badge/resolution/mwclient/mwclient.svg
 [gitter-chat-img]: https://img.shields.io/gitter/room/mwclient/mwclient.svg
 
 mwclient is a lightweight Python client library to the

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Please see the [changelog
 document](https://github.com/mwclient/mwclient/blob/master/CHANGELOG.md)
 for a list of changes.
 
+mwclient was originally written by Bryan Tong Minh. It was maintained
+for many years by Dan Michael O. Heggø, with assistance from Waldir
+Pimenta. It is currently maintained by Marc Trölitzsch, Adam Williamson
+and Megan Cutrofello. The best way to get in touch with the maintainers
+is by filing an issue or a pull request.
+
 ## Documentation
 
 Up-to-date documentation is hosted [at Read the Docs](http://mwclient.readthedocs.io/en/latest/).


### PR DESCRIPTION
This adds a paragraph covering former and current mwclient maintainers. It also fixes the build status badge to come from Github Actions, since we no longer use Travis.