### PR TITLE
Use Coveralls Github Action to send data to coveralls again

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,7 +1,7 @@
 ---
 name: Test Python package with Tox
 
-on: [pull_request]
+on: ["push", "pull_request"]
 
 jobs:
   build:
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install tox tox-gh-actions coverage
       - name: Test with tox
         run: tox
+      - name: Produce coverage.lcov for coveralls
+        if: matrix.python-version == '3.11'
+        run: coverage lcov
+      - name: Coveralls
+        if: matrix.python-version == '3.11'
+        uses: coverallsapp/github-action@v2


### PR DESCRIPTION
This was lost when Travis stopped working, so our coveralls data is frozen in 2021. This should get it working again using https://github.com/marketplace/actions/coveralls-github-action if I got it right.