### PR TITLE
Remove some Python 2.x leftovers

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 import warnings
 import logging
 

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -69,10 +69,6 @@ class List:
             return item[self.return_values]
         return item
 
-    def next(self, *args, **kwargs):
-        """ For Python 2.x support """
-        return self.__next__(*args, **kwargs)
-
     def load_chunk(self):
         """Query a new chunk of data
 

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -90,9 +90,6 @@ class Page:
             self.site
         )
 
-    def __unicode__(self):
-        return self.name
-
     @staticmethod
     def strip_namespace(title):
         if title[0] == ':':

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding=utf-8
 import os
 import sys
 from setuptools import setup

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 from io import StringIO
 import unittest
 import pytest

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 import unittest
 import pytest
 import logging

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 import unittest
 import pytest
 import logging

--- a/test/test_sleep.py
+++ b/test/test_sleep.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 import unittest
 import time
 import pytest

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 import unittest
 import time
 from mwclient.util import parse_timestamp


### PR DESCRIPTION
* `Iterator.next()` has been replaced with `Iterator.__next__()`
* The `object.__unicode__()` method is not used anymore
* Default source encoding has changed from ASCII to UTF-8