### PR TITLE
Add ReadTheDocs links to pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+---
+name: Add documentation links to pull requests
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: mwclient


### PR DESCRIPTION
Use [readthedocs/actions/preview](https://github.com/readthedocs/actions/tree/v1/preview) to add links to ReadTheDocs to pull requests.