### PR TITLE
Add Python 3.13-alpha to Tox/GHA

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13"
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-20.04"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,py310,py311,py312,flake
+envlist = py35,py36,py37,py38,py39,py310,py311,py312,py313,flake
 
 [gh-actions]
 python =
@@ -10,6 +10,7 @@ python =
     3.10: py310
     3.11: py311, flake
     3.12: py312
+    3.13: py313
 
 [testenv]
 deps =


### PR DESCRIPTION
Adds the Python 3.13.0-alpha to Tox and the GitHub action.