### PR TITLE
Implement error handling for MediaWiki warnings on existing files

### DIFF
--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -48,7 +48,18 @@ class ProtectedPageError(EditError, InsufficientPermission):
 
 
 class FileExists(EditError):
-    pass
+    """
+    Raised when trying to upload a file that already exists.
+
+    See also: https://www.mediawiki.org/wiki/API:Upload#Upload_warnings
+    """
+
+    def __init__(self, file_name):
+        self.file_name = file_name
+
+    def __str__(self):
+        return ('The file "{0}" already exists. Set ignore=True to overwrite it.'
+                .format(self.file_name))
 
 
 class LoginError(MwClientError):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -12,7 +12,6 @@ from requests_oauthlib import OAuth1
 
 import unittest.mock as mock
 
-
 if __name__ == "__main__":
     print()
     print("Note: Running in stand-alone mode. Consult the README")
@@ -761,6 +760,33 @@ class TestClientUploadArgs(TestCase):
 
         with pytest.raises(mwclient.errors.InsufficientPermission):
             self.site.upload(filename='Test', file=StringIO('test'))
+
+    def test_upload_file_exists(self):
+        self.configure()
+        self.raw_call.side_effect = [
+            self.makePageResponse(title='File:Test.jpg', imagerepository='local',
+                                  imageinfo=[{
+                                      "comment": "",
+                                      "height": 1440,
+                                      "metadata": [],
+                                      "sha1": "69a764a9cf8307ea4130831a0aa0b9b7f9585726",
+                                      "size": 123,
+                                      "timestamp": "2013-12-22T07:11:07Z",
+                                      "user": "TestUser",
+                                      "width": 2160
+                                  }]),
+            json.dumps({'query': {'tokens': {'csrftoken': self.vars['token']}}}),
+            json.dumps({
+                'upload': {'result': 'Warning',
+                           'warnings': {'duplicate': ['Test.jpg'],
+                                        'exists': 'Test.jpg'},
+                           'filekey': '1apyzwruya84.da2cdk.1.jpg',
+                           'sessionkey': '1apyzwruya84.da2cdk.1.jpg'}
+            })
+        ]
+
+        with pytest.raises(mwclient.errors.FileExists):
+            self.site.upload(file=StringIO('test'), filename='Test.jpg', ignore=False)
 
 
 class TestClientGetTokens(TestCase):


### PR DESCRIPTION
Fixes #211 by raising an error when `ignore=False` and the MediaWiki response contains the `upload.warnings.exists` key. Previously, this warning was logged, but the call to `Site.upload` succeeded. This could be easily missed by users, especially when they haven't configured the log level.