### PR TITLE
Add an automated release workflow using Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Build and publish Python distribution to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    if: startsWith(github.ref, 'refs/tags/v') # only publish to PyPI on version tag pushes
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5.1.0
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/v') # only publish to PyPI on version tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mwclient
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 .eggs
 .tox
 .idea/*
+.coverage
+coverage.lcov

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -109,3 +109,18 @@ When it is ready, push your branch to your remote:
 
 Then you can open a pull request on GitHub. You should see a URL to do this
 when you push your branch.
+
+Making a release
+----------------
+
+These instructions are for maintainers of the project.
+To cut a release, ensure ``CHANGELOG.md`` is updated, then use
+`bump-my-version <https://callowayproject.github.io/bump-my-version/>`_:
+
+.. code:: bash
+
+    $ pip install bump-my-version
+    $ bump-my-version bump major|minor|patch
+
+Then check the commit looks correct and is tagged vX.Y.Z, and push. The
+``.github/workflows/release.yml`` action will publish to PyPI.

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -12,12 +12,14 @@ Development environment
 
 If you plan to submit a pull request, you should first
 `fork <https://github.com/mwclient/mwclient#fork-destination-box>`_
-the mwclient repo on GitHub, then clone your own fork:
+the mwclient repo on GitHub, then check out the original repository
+and configure your fork as a remote:
 
 .. code:: bash
 
-    $ git clone git@github.com:MYUSERNAME/mwclient.git
+    $ git clone https://github.com/mwclient/mwclient.git
     $ cd mwclient
+    $ git remote add fork git@github.com:MYUSERNAME/mwclient.git
 
 You can then use pip to do an "editable" install so that your
 edits will be immediately available for (both interactive
@@ -26,6 +28,12 @@ and automated) testing:
 .. code:: bash
 
     $ pip install -e .
+
+Create a new branch for your changes:
+
+.. code:: bash
+
+    $ git checkout -b my-branch
 
 Test suite
 ----------
@@ -91,7 +99,13 @@ on the main master branch to ease merging:
 
 .. code:: bash
 
-    $ git remote add upstream https://github.com/mwclient/mwclient.git
-    $ git rebase upstream master
+    $ git rebase master
 
-Then push your code and open a pull request on GitHub.
+When it is ready, push your branch to your remote:
+
+.. code:: bash
+
+    $ git push -u fork my-branch
+
+Then you can open a pull request on GitHub. You should see a URL to do this
+when you push your branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "--cov mwclient test"
+
+[tool.bumpversion]
+current_version = "0.10.1"
+commit = true
+tag = true
+
+[[tool.bumpversion.files]]
+filename = "setup.py"
+search = "version='{current_version}'"
+replace = "version='{new_version}'"
+
+[[tool.bumpversion.files]]
+filename = "mwclient/client.py"
+
+[[tool.bumpversion.files]]
+filename = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,24 +1,5 @@
-[bumpversion]
-current_version = 0.10.1
-commit = True
-tag = True
-
 [aliases]
 test = pytest
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:mwclient/client.py]
-
-[bumpversion:file:README.md]
-
-[bdist_wheel]
-universal = 1
-
-[tool:pytest]
-addopts = --cov mwclient test
 
 [flake8]
 max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(name='mwclient',
-      version='0.10.1',  # Use bumpversion to update
+      # See https://mwclient.readthedocs.io/en/latest/development/#making-a-release
+      # for how to update this field and release a new version.
+      version='0.10.1',
       description='MediaWiki API client',
       long_description=README,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This adds a release workflow, and updates tool config a bit to make the latest incarnation of bumpversion happy. I've tested that you can do `bump-my-version bump major` on top of this and it looks like it does everything we'd want - update all the appropriate version strings and create a tagged commit. So I *hope* that, once we merge this, we can submit another PR created by editing `CHANGELOG.md` then running `bump-my-version bump major`, then merge that PR and the release should happen magically.