### PR TITLE
Add several things to MANIFEST.in that are in current tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,11 @@
+include CHANGELOG.md
+include CONTRIBUTING.md
+include CREDITS.md
 include README.md
 include LICENSE.md
+# prospector config - https://github.com/landscapeio/prospector
+include .landscape.yaml
+include .editorconfig
+include tox.ini
+graft docs
+graft examples


### PR DESCRIPTION
The tarballs from current releases have these files in them, but building with `build` does not include them. I don't know if the previous maintainer was using setuptools-scm or something like that, but this should ensure that appropriate files are included in our new tarballs. I left out things like .gitattributes which clearly shouldn't be in a release tarball.