### PR TITLE
Add a sign/GH release job to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,36 @@ jobs:
         path: dist/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Sign the distribution with Sigstore and upload as a GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v') # only publish to GitHub on version tag pushes
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: ./dist/*.tar.gz ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'


### PR DESCRIPTION
This is the one from
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ again, with an `if` condition added and multilines rewrapped. As best as I can tell, this should work automagically, we don't need to "sign up for" sigstore or create any certificates or keys; it works by creating an ephemeral signing certificate bound to the identity of whatever GitHub user the workflow runs as (proved by OIDC), and signing with that.