### PR TITLE
rename `reqs` arg to `connection_options` (#197)

### DIFF
--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -74,7 +74,7 @@ Using a proxy
 -------------
 
 If you need to use a proxy, you can configure the :class:`requests.Session`
-using the `reqs` parameter of the :class:`~mwclient.client.Site`.
+using the `connection_options` parameter of the :class:`~mwclient.client.Site`.
 
 .. code-block:: python
 
@@ -84,7 +84,7 @@ using the `reqs` parameter of the :class:`~mwclient.client.Site`.
       'http': 'http://10.10.1.10:3128',
       'https': 'http://10.10.1.10:1080',
     }
-    site = mwclient.Site('en.wikipedia.org', reqs={"proxy": proxies})
+    site = mwclient.Site('en.wikipedia.org', connection_options={"proxy": proxies})
 
 Errors and warnings
 -------------------

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -65,7 +65,7 @@ class Site:
             text strings are encoded as UTF-8. If dealing with a server that cannot
             handle UTF-8, please provide the username and password already encoded with
             the appropriate encoding.
-        reqs (Dict[str, Any]): Additional arguments to be passed to the
+        connection_options (Dict[str, Any]): Additional arguments to be passed to the
             :py:meth:`requests.Session.request` method when performing API calls. If the
             `timeout` key is empty, a default timeout of 30 seconds is added.
         consumer_token (str): OAuth1 consumer key for owner-only consumers.
@@ -92,9 +92,9 @@ class Site:
     def __init__(self, host, path='/w/', ext='.php', pool=None, retry_timeout=30,
                  max_retries=25, wait_callback=lambda *x: None, clients_useragent=None,
                  max_lag=3, compress=True, force_login=True, do_init=True, httpauth=None,
-                 reqs=None, consumer_token=None, consumer_secret=None, access_token=None,
-                 access_secret=None, client_certificate=None, custom_headers=None,
-                 scheme='https'):
+                 connection_options=None, consumer_token=None, consumer_secret=None,
+                 access_token=None, access_secret=None, client_certificate=None,
+                 custom_headers=None, scheme='https', reqs=None):
         # Setup member variables
         self.host = host
         self.path = path
@@ -103,7 +103,17 @@ class Site:
         self.compress = compress
         self.max_lag = str(max_lag)
         self.force_login = force_login
-        self.requests = reqs or {}
+        if reqs and connection_options:
+            raise ValueError(
+                "reqs is a deprecated alias of connection_options. Do not specify both."
+            )
+        if reqs:
+            warnings.warn(
+                "reqs is deprecated in mwclient 1.0.0. Use connection_options instead",
+                DeprecationWarning
+            )
+            connection_options = reqs
+        self.requests = connection_options or {}
         self.scheme = scheme
         if 'timeout' not in self.requests:
             self.requests['timeout'] = 30  # seconds

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -467,6 +467,18 @@ class TestClient(TestCase):
             site.raw_api("query", "GET", retry_on_error=False)
         assert timesleep.call_count == 25
 
+    @responses.activate
+    def test_connection_options(self):
+        self.httpShouldReturn(self.metaResponseAsJson())
+        args = {"timeout": 60, "stream": False}
+        site = mwclient.Site('test.wikipedia.org', connection_options=args)
+        assert site.requests == args
+        with pytest.warns(DeprecationWarning):
+            site = mwclient.Site('test.wikipedia.org', reqs=args)
+        assert site.requests == args
+        with pytest.raises(ValueError):
+            site = mwclient.Site('test.wikipedia.org', reqs=args, connection_options=args)
+
 class TestLogin(TestCase):
 
     @mock.patch('mwclient.client.Site.site_init')


### PR DESCRIPTION
As discussed in #197, this renames the `reqs` argument to `Site` to `connection_options`. The old name still works but triggers a DeprecationWarning. If you specify both we raise ValueError.