### PR TITLE
Add Type Annotations to the Codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ dist
 .eggs
 .tox
 .idea/*
+.venv/
 .coverage
 coverage.lcov

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -274,3 +274,6 @@ texinfo_documents = [
 intersphinx_mapping = {
   'requests': ('http://requests.readthedocs.org/en/latest/', None)
 }
+
+# Controls the display of typehints in the autodoc output.
+autodoc_typehints = 'description'

--- a/examples/upload.py
+++ b/examples/upload.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO
 import sys
 import os
 import pprint
@@ -48,4 +48,4 @@ assert 'duplicate' in res['warnings']
 assert 'exists' in res['warnings']
 
 print('Uploading empty file; error expected')
-res = site.upload(StringIO(), name, 'Empty upload test')
+res = site.upload(BytesIO(), name, 'Empty upload test')

--- a/mwclient/__init__.py
+++ b/mwclient/__init__.py
@@ -24,7 +24,7 @@
 """
 
 from mwclient.errors import *  # noqa: F401, F403
-from mwclient.client import Site, __version__  # noqa: F401
+from mwclient.client import Site as Site, __version__ as __version__  # noqa: F401
 import logging
 import warnings
 

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -986,7 +986,7 @@ class Site:
         url: Optional[str] = None,
         filekey: Optional[str] = None,
         comment: Optional[str] = None
-    ) -> Any:
+    ) -> Dict[str, Any]:
         """Upload a file to the site.
 
         Note that one of `file`, `filekey` and `url` must be specified, but not
@@ -1098,7 +1098,7 @@ class Site:
             if not info:
                 info = {}
             if self.handle_api_result(info, kwargs=predata, sleeper=sleeper):
-                response = info.get('upload', {})
+                response = info.get('upload', {})  # type: Dict[str, Any]
                 # Workaround for https://github.com/mwclient/mwclient/issues/211
                 # ----------------------------------------------------------------
                 # Raise an error if the file already exists. This is necessary because
@@ -1120,7 +1120,7 @@ class Site:
         ignorewarnings: bool,
         comment: str,
         text: Optional[str]
-    ) -> Any:
+    ) -> Dict[str, Any]:
         """Upload a file to the site in chunks.
 
         This method is called by `Site.upload` if you are connecting to a newer
@@ -1158,7 +1158,7 @@ class Site:
                 data = self.raw_call('api', params, files={'chunk': chunk})
                 info = json.loads(data)
                 if self.handle_api_result(info, kwargs=params, sleeper=sleeper):
-                    response = info.get('upload', {})
+                    response = info.get('upload', {})  # type: Dict[str, Any]
                     break
 
             offset += chunk.tell()

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -685,7 +685,7 @@ class Site:
         minor: int,
         revision: Optional[int] = None,
         raise_error: bool = True
-    ) -> bool:
+    ) -> Optional[bool]:
         """Check whether the current wiki matches the required version.
 
         Args:
@@ -697,8 +697,8 @@ class Site:
 
         Returns:
             `False` if the version of the current wiki is below the required version, else
-                `True`. If either `raise_error=True` or the site is uninitialized and
-                `raise_error=None` then nothing is returned.
+                `True`. If `raise_error` is `False` and the version is below the required
+                version, `None` is returned.
 
         Raises:
             errors.MediaWikiVersionError: The current wiki is below the required version
@@ -713,9 +713,17 @@ class Site:
         """
         if self.version is None:
             if raise_error is None:
-                return  # type: ignore[unreachable]
-            # FIXME: Replace this with a specific error
-            raise RuntimeError(f'Site {repr(self)} has not yet been initialized')
+                warnings.warn(  # type: ignore[unreachable]
+                    'Passing raise_error=None to require is deprecated and will be '
+                    'removed in a future version. Use raise_error=False instead.',
+                    DeprecationWarning
+                )
+                return None
+            elif raise_error is False:
+                return None
+            else:
+                # FIXME: Replace this with a specific error
+                raise RuntimeError(f'Site {repr(self)} has not yet been initialized')
 
         if revision is None:
             if self.version[:2] >= (major, minor):

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1,7 +1,10 @@
+import io
 import json
 import logging
 import warnings
 from collections import OrderedDict
+from typing import Optional, Callable, Union, Mapping, Any, MutableMapping, List, Dict, \
+    Tuple, cast, Iterable, BinaryIO, TextIO, Iterator
 
 import requests
 from requests.auth import HTTPBasicAuth, AuthBase
@@ -9,7 +12,8 @@ from requests_oauthlib import OAuth1
 
 import mwclient.errors as errors
 import mwclient.listing as listing
-from mwclient.sleep import Sleepers
+from mwclient.sleep import Sleeper, Sleepers
+from mwclient.types import Namespace
 from mwclient.util import parse_timestamp, read_in_chunks, handle_limit
 
 __version__ = '0.11.0'
@@ -28,53 +32,50 @@ class Site:
         >>> wikia_site = mwclient.Site('vim.wikia.com', path='/')
 
     Args:
-        host (str): The hostname of a MediaWiki instance. Must not include a
-            scheme (e.g. `https://`) - use the `scheme` argument instead.
-        path (str): The instances script path (where the `index.php` and `api.php` scripts
-            are located). Must contain a trailing slash (`/`). Defaults to `/w/`.
-        ext (str): The file extension used by the MediaWiki API scripts. Defaults to
-            `.php`.
-        pool (requests.Session): A preexisting :class:`~requests.Session` to be used when
-            executing API requests.
-        retry_timeout (int): The number of seconds to sleep for each past retry of a
-            failing API request. Defaults to `30`.
-        max_retries (int): The maximum number of retries to perform for failing API
-            requests. Defaults to `25`.
-        wait_callback (Callable): A callback function to be executed for each failing
-            API request.
-        clients_useragent (str): A prefix to be added to the default mwclient user-agent.
-            Should follow the pattern `'{tool_name}/{tool_version} ({contact})'`. Check
-            the `User-Agent policy <https://meta.wikimedia.org/wiki/User-Agent_policy>`_
+        host: The hostname of a MediaWiki instance. Must not include a scheme
+            (e.g. `https://`) - use the `scheme` argument instead.
+        path: The instances script path (where the `index.php` and `api.php` scripts are
+            located). Must contain a trailing slash (`/`). Defaults to `/w/`.
+        ext: The file extension used by the MediaWiki API scripts. Defaults to `.php`.
+        pool: A preexisting :class:`~requests.Session` to be used when executing API
+            requests.
+        retry_timeout: The number of seconds to sleep for each past retry of a failing API
+            request. Defaults to `30`.
+        max_retries: The maximum number of retries to perform for failing API requests.
+            Defaults to `25`.
+        wait_callback: A callback function to be executed for each failing API request.
+        clients_useragent: A prefix to be added to the default mwclient user-agent. Should
+            follow the pattern `'{tool_name}/{tool_version} ({contact})'`. Check the
+            `User-Agent policy <https://meta.wikimedia.org/wiki/User-Agent_policy>`_
             for more information.
-        max_lag (int): A `maxlag` parameter to be used in `index.php` calls. Consult the
+        max_lag: A `maxlag` parameter to be used in `index.php` calls. Consult the
             `documentation <https://www.mediawiki.org/wiki/Manual:Maxlag_parameter>`_ for
             more information. Defaults to `3`.
-        compress (bool): Whether to request and accept gzip compressed API responses.
-            Defaults to `True`.
-        force_login (bool): Whether to require authentication when editing pages. Set to
-            `False` to allow unauthenticated edits. Defaults to `True`.
-        do_init (bool): Whether to automatically initialize the :py:class:`Site` on
+        compress: Whether to request and accept gzip compressed API responses. Defaults to
+             `True`.
+        force_login: Whether to require authentication when editing pages. Set to `False`
+            to allow unauthenticated edits. Defaults to `True`.
+        do_init: Whether to automatically initialize the :py:class:`Site` on
             initialization. When set to `False`, the :py:class:`Site` must be initialized
             manually using the :py:meth:`.site_init` method. Defaults to `True`.
-        httpauth (Union[tuple[basestring, basestring], requests.auth.AuthBase]): An
-            authentication method to be used when making API requests. This can be either
-            an authentication object as provided by the :py:mod:`requests` library, or a
-            tuple in the form `{username, password}`. Usernames and passwords provided as
-            text strings are encoded as UTF-8. If dealing with a server that cannot
-            handle UTF-8, please provide the username and password already encoded with
-            the appropriate encoding.
-        connection_options (Dict[str, Any]): Additional arguments to be passed to the
+        httpauth: An authentication method to be used when making API requests. This can
+            be either an authentication object as provided by the :py:mod:`requests`
+            library, or a tuple in the form `{username, password}`. Usernames and
+            passwords provided as text strings are encoded as UTF-8. If dealing with a
+            server that cannot handle UTF-8, please provide the username and password
+            already encoded with the appropriate encoding.
+        connection_options: Additional arguments to be passed to the
             :py:meth:`requests.Session.request` method when performing API calls. If the
             `timeout` key is empty, a default timeout of 30 seconds is added.
-        consumer_token (str): OAuth1 consumer key for owner-only consumers.
-        consumer_secret (str): OAuth1 consumer secret for owner-only consumers.
-        access_token (str): OAuth1 access key for owner-only consumers.
-        access_secret (str): OAuth1 access secret for owner-only consumers.
-        client_certificate (Union[str, tuple[str, str]]): A client certificate to be added
+        consumer_token: OAuth1 consumer key for owner-only consumers.
+        consumer_secret: OAuth1 consumer secret for owner-only consumers.
+        access_token: OAuth1 access key for owner-only consumers.
+        access_secret: OAuth1 access secret for owner-only consumers.
+        client_certificate: A client certificate to be added
             to the session.
-        custom_headers (Dict[str, str]): A dictionary of custom headers to be added to all
+        custom_headers: A dictionary of custom headers to be added to all
             API requests.
-        scheme (str): The URI scheme to use. This should be either `http` or `https` in
+        scheme: The URI scheme to use. This should be either `http` or `https` in
             most cases. Defaults to `https`.
 
     Raises:
@@ -87,17 +88,41 @@ class Site:
     """
     api_limit = 500
 
-    def __init__(self, host, path='/w/', ext='.php', pool=None, retry_timeout=30,
-                 max_retries=25, wait_callback=lambda *x: None, clients_useragent=None,
-                 max_lag=3, compress=True, force_login=True, do_init=True, httpauth=None,
-                 connection_options=None, consumer_token=None, consumer_secret=None,
-                 access_token=None, access_secret=None, client_certificate=None,
-                 custom_headers=None, scheme='https', reqs=None):
+    def __init__(
+        self,
+        host: str,
+        path: str = '/w/',
+        ext: str = '.php',
+        pool: Optional[requests.Session] = None,
+        retry_timeout: int = 30,
+        max_retries: int = 25,
+        wait_callback: Callable[['Sleeper', int, Optional[Any]], Any] = lambda *x: None,
+        clients_useragent: Optional[str] = None,
+        max_lag: int = 3,
+        compress: bool = True,
+        force_login: bool = True,
+        do_init: bool = True,
+        httpauth: Union[
+            Tuple[Union[str, bytes], Union[str, bytes]],
+            requests.auth.AuthBase,
+            List[Union[str, bytes]],
+            None,
+        ] = None,
+        connection_options: Optional[MutableMapping[str, Any]] = None,
+        consumer_token: Optional[str] = None,
+        consumer_secret: Optional[str] = None,
+        access_token: Optional[str] = None,
+        access_secret: Optional[str] = None,
+        client_certificate: Optional[Union[str, Tuple[str, str]]] = None,
+        custom_headers: Optional[Mapping[str, str]] = None,
+        scheme: str = 'https',
+        reqs: Optional[MutableMapping[str, Any]] = None
+    ) -> None:
         # Setup member variables
         self.host = host
         self.path = path
         self.ext = ext
-        self.credentials = None
+        self.credentials = None  # type: Optional[Tuple[str, str, Optional[str]]]
         self.compress = compress
         self.max_lag = str(max_lag)
         self.force_login = force_login
@@ -136,18 +161,18 @@ class Site:
         self.sleepers = Sleepers(max_retries, retry_timeout, wait_callback)
 
         # Site properties
-        self.blocked = False    # Whether current user is blocked
+        self.blocked = False  # type: Union[Tuple[str, str], bool]  # Is user blocked?
         self.hasmsg = False  # Whether current user has new messages
-        self.groups = []    # Groups current user belongs to
-        self.rights = []    # Rights current user has
-        self.tokens = {}    # Edit tokens of the current user
-        self.version = None
+        self.groups = []  # type: List[str]  # Groups current user is in
+        self.rights = []  # type: List[str]  # Rights current user has
+        self.tokens = {}  # type: Dict[str, str]  # Edit tokens of the current user
+        self.version = None  # type: Union[Tuple[int, ...], Tuple[int, str], None]
 
-        self.namespaces = self.default_namespaces
+        self.namespaces = self.default_namespaces  # type: Dict[int, str]
 
         # Setup connection
         if pool is None:
-            self.connection = requests.Session()
+            self.connection = requests.Session()  # type: requests.Session
             self.connection.auth = auth
             if client_certificate:
                 self.connection.cert = client_certificate
@@ -191,7 +216,7 @@ class Site:
                 if e.args[0] not in {'unknown_action', 'readapidenied'}:
                     raise
 
-    def site_init(self):
+    def site_init(self) -> None:
         """Populates the object with information about the current user and site. This is
         done automatically when creating the object, unless explicitly disabled using the
         `do_init=False` constructor argument."""
@@ -229,7 +254,9 @@ class Site:
         self.initialized = True
 
     @staticmethod
-    def version_tuple_from_generator(string, prefix='MediaWiki '):
+    def version_tuple_from_generator(
+        string: str, prefix: str = 'MediaWiki '
+    ) -> Union[Tuple[int, ...], Tuple[int, str]]:
         """Return a version tuple from a MediaWiki Generator string.
 
         Example:
@@ -237,8 +264,8 @@ class Site:
             (1, 5, 1)
 
         Args:
-            string (str): The MediaWiki Generator string.
-            prefix (str): The expected prefix of the string.
+            string: The MediaWiki Generator string.
+            prefix: The expected prefix of the string.
 
         Returns:
             tuple[int, int, Union[int, str]...]: The version tuple.
@@ -248,7 +275,7 @@ class Site:
 
         version = string[len(prefix):]
 
-        def _split_version(version):
+        def _split_version(version: str) -> Iterator[str]:
             """Split a version string into segments.
 
             Args:
@@ -299,45 +326,51 @@ class Site:
         -1: 'Special', -2: 'Media'
     }
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} object '{self.host}{self.path}'>"
 
-    def get(self, action, *args, **kwargs):
+    def get(self, action: str, *args: Tuple[str, Any], **kwargs: Any) -> Dict[str, Any]:
         """Perform a generic API call using GET.
 
         This is just a shorthand for calling api() with http_method='GET'.
         All arguments will be passed on.
 
         Args:
-            action (str): The MediaWiki API action to be performed.
+            action: The MediaWiki API action to be performed.
 
         Returns:
             The raw response from the API call, as a dictionary.
         """
         return self.api(action, 'GET', *args, **kwargs)
 
-    def post(self, action, *args, **kwargs):
+    def post(self, action: str, *args: Tuple[str, Any], **kwargs: Any) -> Dict[str, Any]:
         """Perform a generic API call using POST.
 
         This is just a shorthand for calling api() with http_method='POST'.
         All arguments will be passed on.
 
         Args:
-            action (str): The MediaWiki API action to be performed.
+            action: The MediaWiki API action to be performed.
 
         Returns:
             The raw response from the API call, as a dictionary.
         """
         return self.api(action, 'POST', *args, **kwargs)
 
-    def api(self, action, http_method='POST', *args, **kwargs):
+    def api(
+        self,
+        action: str,
+        http_method: str = 'POST',
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Perform a generic API call and handle errors.
 
         All arguments will be passed on.
 
         Args:
-            action (str): The MediaWiki API action to be performed.
-            http_method (str): The HTTP method to use.
+            action: The MediaWiki API action to be performed.
+            http_method: The HTTP method to use.
 
         Example:
             To get coordinates from the GeoData MediaWiki extension at English Wikipedia:
@@ -381,16 +414,20 @@ class Site:
             if self.handle_api_result(info, sleeper=sleeper):
                 return info
 
-    def handle_api_result(self, info, kwargs=None, sleeper=None):
+    def handle_api_result(
+        self,
+        info: Mapping[str, Any],
+        kwargs: Optional[Mapping[str, Any]] = None,
+        sleeper: Optional['Sleeper'] = None
+    ) -> bool:
         """Checks the given API response, raising an appropriate exception or sleeping if
         necessary.
 
         Args:
-            info (dict): The API result.
-            kwargs (dict): Additional arguments to be passed when raising an
+            info: The API result.
+            kwargs: Additional arguments to be passed when raising an
                 :class:`errors.APIError`.
-            sleeper (sleep.Sleeper): A :class:`~sleep.Sleeper` instance to use when
-                sleeping.
+            sleeper: A :class:`~sleep.Sleeper` instance to use when sleeping.
 
         Returns:
             `False` if the given API response contains an exception, else `True`.
@@ -443,7 +480,7 @@ class Site:
         return True
 
     @staticmethod
-    def _query_string(*args, **kwargs):
+    def _query_string(*args: Tuple[str, Any], **kwargs: Any) -> Dict[str, Any]:
         kwargs.update(args)
         qs1 = [
             (k, v) for k, v in kwargs.items() if k not in {'wpEditToken', 'token'}
@@ -453,7 +490,16 @@ class Site:
         ]
         return OrderedDict(qs1 + qs2)
 
-    def raw_call(self, script, data, files=None, retry_on_error=True, http_method='POST'):
+    def raw_call(
+        self,
+        script: str,
+        data: Mapping[str, Any],
+        files: Optional[
+            Mapping[str, Union[io.BytesIO, Tuple[str, io.BufferedReader]]]
+        ] = None,
+        retry_on_error: bool = True,
+        http_method: str = 'POST'
+    ) -> str:
         """
         Perform a generic request and return the raw text.
 
@@ -466,11 +512,11 @@ class Site:
         HTTP responses.
 
         Args:
-            script (str): Script name, usually 'api'.
-            data (dict): Post data
-            files (dict): Files to upload
-            retry_on_error (bool): Retry on connection error
-            http_method (str): The HTTP method, defaults to 'POST'
+            script: Script name, usually 'api'.
+            data: Post data
+            files: Files to upload
+            retry_on_error: Retry on connection error
+            http_method: The HTTP method, defaults to 'POST'
 
         Returns:
             The raw text response.
@@ -491,8 +537,8 @@ class Site:
 
         scheme = self.scheme
         host = self.host
-        if isinstance(host, (list, tuple)):
-            warnings.warn(
+        if isinstance(host, (list, tuple)):  # type: ignore[unreachable]
+            warnings.warn(  # type: ignore[unreachable]
                 'Specifying host as a tuple is deprecated as of mwclient 0.10.1. '
                 + 'Please use the new scheme argument instead.',
                 DeprecationWarning
@@ -504,7 +550,7 @@ class Site:
         while True:
             toraise = None
             wait_time = 0
-            args = {'files': files, 'headers': headers}
+            args = {'files': files, 'headers': headers}  # type: Dict[str, Any]
             for k, v in self.requests.items():
                 args[k] = v
             if http_method == 'GET':
@@ -515,7 +561,9 @@ class Site:
             try:
                 stream = self.connection.request(http_method, url, **args)
                 if stream.headers.get('x-database-lag'):
-                    wait_time = int(stream.headers.get('retry-after'))
+                    wait_time = int(
+                        stream.headers.get('retry-after')  # type: ignore[arg-type]
+                    )
                     log.warning('Database lag exceeds max lag. '
                                 'Waiting for %d seconds', wait_time)
                     # fall through to the sleep
@@ -544,7 +592,7 @@ class Site:
                 if not retry_on_error:
                     raise
                 log.warning('Connection error. Retrying in a moment.')
-                toraise = err
+                toraise = err  # type: ignore[assignment]
                 # proceed to the sleep
 
             # all retry paths come here
@@ -554,20 +602,26 @@ class Site:
                 if toraise == "stream":
                     stream.raise_for_status()
                 elif toraise:
-                    raise toraise
+                    raise toraise  # type: ignore[misc]
                 else:
                     raise
 
-    def raw_api(self, action, http_method='POST', retry_on_error=True, *args, **kwargs):
+    def raw_api(
+        self,
+        action: str,
+        http_method: str = 'POST',
+        retry_on_error: bool = True,
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Send a call to the API.
 
         Args:
-            action (str): The MediaWiki API action to perform.
-            http_method (str): The HTTP method to use in the request.
-            retry_on_error (bool): Whether to retry API call on connection errors.
-            *args (Tuple[str, Any]): Arguments to be passed to the `api.php` script as
-                data.
-            **kwargs (Any): Arguments to be passed to the `api.php` script as data.
+            action: The MediaWiki API action to perform.
+            http_method: The HTTP method to use in the request.
+            retry_on_error: Whether to retry API call on connection errors.
+            *args: Arguments to be passed to the `api.php` script as data.
+            **kwargs: Arguments to be passed to the `api.php` script as data.
 
         Returns:
             The API response.
@@ -590,21 +644,26 @@ class Site:
                             http_method=http_method)
 
         try:
-            return json.loads(res, object_pairs_hook=OrderedDict)
+            return cast(Dict[str, Any], json.loads(res, object_pairs_hook=OrderedDict))
         except ValueError:
             if res.startswith('MediaWiki API is not enabled for this site.'):
                 raise errors.APIDisabledError
             raise errors.InvalidResponse(res)
 
-    def raw_index(self, action, http_method='POST', *args, **kwargs):
+    def raw_index(
+        self,
+        action: str,
+        http_method: str = 'POST',
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> str:
         """Sends a call to index.php rather than the API.
 
         Args:
-            action (str): The MediaWiki API action to perform.
-            http_method (str): The HTTP method to use in the request.
-            *args (Tuple[str, Any]): Arguments to be passed to the `index.php` script as
-                data.
-            **kwargs (Any): Arguments to be passed to the `index.php` script as data.
+            action: The MediaWiki API action to perform.
+            http_method: The HTTP method to use in the request.
+            *args: Arguments to be passed to the `index.php` script as data.
+            **kwargs: Arguments to be passed to the `index.php` script as data.
 
         Returns:
             The API response.
@@ -623,15 +682,21 @@ class Site:
         data = self._query_string(*args, **kwargs)
         return self.raw_call('index', data, http_method=http_method)
 
-    def require(self, major, minor, revision=None, raise_error=True):
+    def require(
+        self,
+        major: int,
+        minor: int,
+        revision: Optional[int] = None,
+        raise_error: bool = True
+    ) -> bool:
         """Check whether the current wiki matches the required version.
 
         Args:
-            major (int): The required major version.
-            minor (int): The required minor version.
-            revision (int): The required revision.
-            raise_error (bool): Whether to throw an error if the version of the current
-                wiki is below the required version. Defaults to `True`.
+            major: The required major version.
+            minor: The required minor version.
+            revision: The required revision.
+            raise_error: Whether to throw an error if the version of the current wiki is
+                below the required version. Defaults to `True`.
 
         Returns:
             `False` if the version of the current wiki is below the required version, else
@@ -651,7 +716,7 @@ class Site:
         """
         if self.version is None:
             if raise_error is None:
-                return
+                return  # type: ignore[unreachable]
             # FIXME: Replace this with a specific error
             raise RuntimeError(f'Site {repr(self)} has not yet been initialized')
 
@@ -668,7 +733,9 @@ class Site:
             raise NotImplementedError
 
     # Actions
-    def email(self, user, text, subject, cc=False):
+    def email(
+        self, user: str, text: str, subject: str, cc: bool = False
+    ) -> Dict[str, Any]:
         """
         Send email to a specified user on the wiki.
 
@@ -677,11 +744,13 @@ class Site:
             ... except mwclient.errors.NoSpecifiedEmail:
             ...     print('User does not accept email, or has no email address.')
 
+        API doc: https://www.mediawiki.org/wiki/API:Email
+
         Args:
-            user (str): User name of the recipient
-            text (str): Body of the email
-            subject (str): Subject of the email
-            cc (bool): True to send a copy of the email to yourself (default is False)
+            user: Username of the recipient
+            text: Body of the email
+            subject: Subject of the email
+            cc: True to send a copy of the email to yourself (default is False)
 
         Returns:
             Dictionary of the JSON response
@@ -699,11 +768,17 @@ class Site:
         except errors.APIError as e:
             if e.args[0] == 'noemail':
                 raise errors.NoSpecifiedEmail(user, e.args[1])
-            raise errors.EmailError(*e)
+            raise errors.EmailError(*e)  # type: ignore[misc]
 
         return info
 
-    def login(self, username=None, password=None, cookies=None, domain=None):
+    def login(
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        cookies: Optional[Mapping[str, str]] = None,
+        domain: Optional[str] = None
+    ) -> None:
         """
         Login to the wiki using a username and bot password. The method returns
         nothing if the login was successful, but raises and error if it was not.
@@ -720,11 +795,11 @@ class Site:
               with a user who has userrights permission (a bureaucrat for eg.).
 
         Args:
-            username (str): MediaWiki username
-            password (str): MediaWiki password
-            cookies (dict): Custom cookies to include with the log-in request.
-            domain (str): Sends domain name for authentication; used by some
-                MediaWiki plug-ins like the 'LDAP Authentication' extension.
+            username: MediaWiki username
+            password: MediaWiki password
+            cookies: Custom cookies to include with the log-in request.
+            domain: Sends domain name for authentication; used by some MediaWiki plug-ins
+                like the 'LDAP Authentication' extension.
 
         Raises:
             LoginError (mwclient.errors.LoginError): Login failed, the reason can be
@@ -777,7 +852,9 @@ class Site:
 
         self.site_init()
 
-    def clientlogin(self, cookies=None, **kwargs):
+    def clientlogin(
+        self, cookies: Optional[Mapping[str, str]] = None, **kwargs: Any
+    ) -> Any:
         """
         Login to the wiki using a username and password. The method returns
         True if it's a success or the returned response if it's a multi-steps
@@ -790,8 +867,8 @@ class Site:
             ...     print(f'Could not login to MediaWiki: {e}' )
 
         Args:
-            cookies (dict): Custom cookies to include with the log-in request.
-            **kwargs (dict): Custom vars used for clientlogin as:
+            cookies: Custom cookies to include with the log-in request.
+            **kwargs: Custom vars used for clientlogin as:
                 - loginmergerequestfields
                 - loginpreservestate
                 - loginreturnurl,
@@ -848,15 +925,17 @@ class Site:
         else:
             raise errors.LoginError(self, status, response['clientlogin'].get('message'))
 
-    def get_token(self, type, force=False, title=None):
+    def get_token(
+        self, type: str, force: bool = False, title: Optional[str] = None
+    ) -> str:
         """Request a MediaWiki access token of the given `type`.
 
         Args:
-            type (str): The type of token to request.
-            force (bool): Force the request of a new token, even if a token of that type
-                has already been cached.
-            title (str): The page title for which to request a token. Only used for
-                MediaWiki versions below 1.24.
+            type: The type of token to request.
+            force: Force the request of a new token, even if a token of that type has
+                already been cached.
+            title: The page title for which to request a token. Only used for MediaWiki
+                versions below 1.24.
 
         Returns:
             A MediaWiki token of the requested `type`.
@@ -899,25 +978,34 @@ class Site:
 
         return self.tokens[type]
 
-    def upload(self, file=None, filename=None, description='', ignore=False,
-               file_size=None, url=None, filekey=None, comment=None):
+    def upload(
+        self,
+        file: Union[str, BinaryIO, TextIO, None] = None,
+        filename: Optional[str] = None,
+        description: str = '',
+        ignore: bool = False,
+        file_size: Optional[int] = None,
+        url: Optional[str] = None,
+        filekey: Optional[str] = None,
+        comment: Optional[str] = None
+    ) -> Any:
         """Upload a file to the site.
 
         Note that one of `file`, `filekey` and `url` must be specified, but not
         more than one. For normal uploads, you specify `file`.
 
+        API doc: https://www.mediawiki.org/wiki/API:Upload
+
         Args:
-            file (str): File object or stream to upload.
-            filename (str): Destination filename, don't include namespace
-                            prefix like 'File:'
-            description (str): Wikitext for the file description page.
-            ignore (bool): True to upload despite any warnings.
-            file_size (int): Deprecated in mwclient 0.7
-            url (str): URL to fetch the file from.
-            filekey (str): Key that identifies a previous upload that was
-                           stashed temporarily.
-            comment (str): Upload comment. Also used as the initial page text
-                           for new files if `description` is not specified.
+            file: File object or stream to upload.
+            filename: Destination filename, don't include namespace prefix like 'File:'
+            description: Wikitext for the file description page.
+            ignore: True to upload despite any warnings.
+            file_size: Deprecated in mwclient 0.7
+            url: URL to fetch the file from.
+            filekey: Key that identifies a previous upload that was stashed temporarily.
+            comment: Upload comment. Also used as the initial page text for new files if
+                     `description` is not specified.
 
         Example:
 
@@ -963,10 +1051,15 @@ class Site:
             if not hasattr(file, 'read'):
                 file = open(file, 'rb')
 
+            # Narrowing the type of file from Union[str, io.BufferedReader] to just
+            # io.BufferedReader, since we know it's not a string at this point.
+            file = cast(io.BufferedReader, file)
+
             content_size = file.seek(0, 2)
             file.seek(0)
 
-            if self.require(1, 20, raise_error=False) and content_size > self.chunk_size:
+            if (self.require(1, 20, raise_error=False)  # type: ignore[index]
+                    and content_size > self.chunk_size):
                 return self.chunk_upload(file, filename, ignore, comment, text)
 
         predata = {
@@ -985,7 +1078,7 @@ class Site:
 
         # sessionkey was renamed to filekey in MediaWiki 1.18
         # https://phabricator.wikimedia.org/rMW5f13517e36b45342f228f3de4298bb0fe186995d
-        if not self.require(1, 18, raise_error=False):
+        if not self.require(1, 18, raise_error=False):  # type: ignore[index]
             predata['sessionkey'] = filekey
         else:
             predata['filekey'] = filekey
@@ -993,7 +1086,6 @@ class Site:
         postdata = predata
         files = None
         if file is not None:
-
             # Workaround for https://github.com/mwclient/mwclient/issues/65
             # ----------------------------------------------------------------
             # Since the filename in Content-Disposition is not interpreted,
@@ -1023,7 +1115,14 @@ class Site:
             file.close()
         return response
 
-    def chunk_upload(self, file, filename, ignorewarnings, comment, text):
+    def chunk_upload(
+        self,
+        file: io.BufferedReader,
+        filename: str,
+        ignorewarnings: bool,
+        comment: str,
+        text: Optional[str]
+    ) -> Any:
         """Upload a file to the site in chunks.
 
         This method is called by `Site.upload` if you are connecting to a newer
@@ -1031,8 +1130,11 @@ class Site:
         method directly.
 
         Args:
-            file (file-like object): File object or stream to upload.
-            params (dict): Dict containing upload parameters.
+            file: File object or stream to upload.
+            filename: Destination filename.
+            ignorewarnings: True to upload despite any warnings.
+            comment: Upload comment.
+            text: Initial page text for new files.
         """
         image = self.Images[filename]
 
@@ -1084,20 +1186,29 @@ class Site:
         params['text'] = text
         return self.post('upload', **params)
 
-    def parse(self, text=None, title=None, page=None, prop=None,
-              redirects=False, mobileformat=False):
+    def parse(
+        self,
+        text: Optional[str] = None,
+        title: Optional[str] = None,
+        page: Optional[str] = None,
+        prop: Optional[str] = None,
+        redirects: bool = False,
+        mobileformat: bool = False
+    ) -> Any:
         """Parses the given content and returns parser output.
 
+        API doc: https://www.mediawiki.org/wiki/API:Parse
+
         Args:
-            text (str): Text to parse.
-            title (str): Title of page the text belongs to.
-            page (str): The name of a page to parse. Cannot be used together with text
+            text: Text to parse.
+            title: Title of page the text belongs to.
+            page: The name of a page to parse. Cannot be used together with text
                 and title.
-            prop (str): Which pieces of information to get. Multiple alues should be
+            prop: Which pieces of information to get. Multiple alues should be
                 separated using the pipe (`|`) character.
-            redirects (bool): Resolve the redirect, if the given `page` is a redirect.
+            redirects: Resolve the redirect, if the given `page` is a redirect.
                 Defaults to `False`.
-            mobileformat (bool): Return parse output in a format suitable for mobile
+            mobileformat: Return parse output in a format suitable for mobile
                 devices. Defaults to `False`.
 
         Returns:
@@ -1123,7 +1234,12 @@ class Site:
     # def unblock: TODO?
     # def import: TODO?
 
-    def patrol(self, rcid=None, revid=None, tags=None):
+    def patrol(
+        self,
+        rcid: Optional[int] = None,
+        revid: Optional[int] = None,
+        tags: Optional[str] = None
+    ) -> Any:
         """Patrol a page or a revision. Either ``rcid`` or ``revid`` (but not both) must
         be given.
         The ``rcid`` and ``revid`` arguments may be obtained using the
@@ -1132,9 +1248,9 @@ class Site:
         API doc: https://www.mediawiki.org/wiki/API:Patrol
 
         Args:
-            rcid (int): The recentchanges ID to patrol.
-            revid (int): The revision ID to patrol.
-            tags (str): Change tags to apply to the entry in the patrol log. Multiple
+            rcid: The recentchanges ID to patrol.
+            revid: The revision ID to patrol.
+            tags: Change tags to apply to the entry in the patrol log. Multiple
                 tags can be given, by separating them with the pipe (|) character.
 
         Returns:
@@ -1163,11 +1279,29 @@ class Site:
         return result['patrol']
 
     # Lists
-    def allpages(self, start=None, prefix=None, namespace='0', filterredir='all',
-                 minsize=None, maxsize=None, prtype=None, prlevel=None,
-                 limit=None, dir='ascending', filterlanglinks='all', generator=True,
-                 end=None, max_items=None, api_chunk_size=None):
-        """Retrieve all pages on the wiki as a generator."""
+    def allpages(
+        self,
+        start: Optional[str] = None,
+        prefix: Optional[str] = None,
+        namespace: Namespace = '0',
+        filterredir: str = 'all',
+        minsize: Optional[int] = None,
+        maxsize: Optional[int] = None,
+        prtype: Optional[str] = None,
+        prlevel: Optional[str] = None,
+        limit: Optional[int] = None,
+        dir: str = 'ascending',
+        filterlanglinks: str = 'all',
+        generator: bool = True,
+        end: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve all pages on the wiki as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Allpages
+        """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('ap', generator)
@@ -1183,17 +1317,33 @@ class Site:
                                                 return_values='title',
                                                 **kwargs)
 
-    def allimages(self, start=None, prefix=None, minsize=None, maxsize=None, limit=None,
-                  dir='ascending', sha1=None, sha1base36=None, generator=True, end=None,
-                  max_items=None, api_chunk_size=None):
-        """Retrieve all images on the wiki as a generator."""
+    def allimages(
+        self,
+        start: Optional[str] = None,
+        prefix: Optional[str] = None,
+        minsize: Optional[int] = None,
+        maxsize: Optional[int] = None,
+        limit: Optional[int] = None,
+        dir: str = 'ascending',
+        sha1: Optional[str] = None,
+        sha1base36: Optional[str] = None,
+        generator: bool = True,
+        end: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve all images on the wiki as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Allimages
+        """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('ai', generator)
         kwargs = dict(listing.List.generate_kwargs(
             pfx, ('from', start), ('to', end), prefix=prefix,
             minsize=minsize, maxsize=maxsize,
-            dir=dir, sha1=sha1, sha1base36=sha1base36,
+            dir=dir, sha1=sha1, sha1base36=sha1base36
         ))
         return listing.List.get_list(generator)(self, 'allimages', 'ai',
                                                 max_items=max_items,
@@ -1201,10 +1351,24 @@ class Site:
                                                 return_values='timestamp|url',
                                                 **kwargs)
 
-    def alllinks(self, start=None, prefix=None, unique=False, prop='title',
-                 namespace='0', limit=None, generator=True, end=None, max_items=None,
-                 api_chunk_size=None):
-        """Retrieve a list of all links on the wiki as a generator."""
+    def alllinks(
+        self,
+        start: Optional[str] = None,
+        prefix: Optional[str] = None,
+        unique: bool = False,
+        prop: str = 'title',
+        namespace: Namespace = '0',
+        limit: Optional[int] = None,
+        generator: bool = True,
+        end: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve a list of all links on the wiki as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Alllinks
+        """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('al', generator)
@@ -1218,9 +1382,22 @@ class Site:
                                                 api_chunk_size=api_chunk_size,
                                                 return_values='title', **kwargs)
 
-    def allcategories(self, start=None, prefix=None, dir='ascending', limit=None,
-                      generator=True, end=None, max_items=None, api_chunk_size=None):
-        """Retrieve all categories on the wiki as a generator."""
+    def allcategories(
+        self,
+        start: Optional[str] = None,
+        prefix: Optional[str] = None,
+        dir: str = 'ascending',
+        limit: Optional[int] = None,
+        generator: bool = True,
+        end: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve all categories on the wiki as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Allcategories
+        """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('ac', generator)
@@ -1230,10 +1407,25 @@ class Site:
                                                 max_items=max_items,
                                                 api_chunk_size=api_chunk_size, **kwargs)
 
-    def allusers(self, start=None, prefix=None, group=None, prop=None, limit=None,
-                 witheditsonly=False, activeusers=False, rights=None, end=None,
-                 max_items=None, api_chunk_size=None):
-        """Retrieve all users on the wiki as a generator."""
+    def allusers(
+        self,
+        start: Optional[str] = None,
+        prefix: Optional[str] = None,
+        group: Optional[str] = None,
+        prop: Optional[str] = None,
+        limit: Optional[int] = None,
+        witheditsonly: bool = False,
+        activeusers: bool = False,
+        rights: Optional[str] = None,
+        end: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve all users on the wiki as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Allusers
+        """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('au', ('from', start), ('to', end),
@@ -1245,9 +1437,18 @@ class Site:
         return listing.List(self, 'allusers', 'au', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def blocks(self, start=None, end=None, dir='older', ids=None, users=None, limit=None,
-               prop='id|user|by|timestamp|expiry|reason|flags', max_items=None,
-               api_chunk_size=None):
+    def blocks(
+        self,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        dir: str = 'older',
+        ids: Optional[str] = None,
+        users: Optional[str] = None,
+        limit: Optional[int] = None,
+        prop: str = 'id|user|by|timestamp|expiry|reason|flags',
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
         """Retrieve blocks as a generator.
 
         API doc: https://www.mediawiki.org/wiki/API:Blocks
@@ -1279,9 +1480,22 @@ class Site:
         return listing.List(self, 'blocks', 'bk', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def deletedrevisions(self, start=None, end=None, dir='older', namespace=None,
-                         limit=None, prop='user|comment', max_items=None,
-                         api_chunk_size=None):
+    def deletedrevisions(
+        self,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        dir: str = 'older',
+        namespace: Optional[int] = None,
+        limit: Optional[int] = None,
+        prop: str = 'user|comment',
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve deleted revisions as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Deletedrevs
+        """
         # TODO: Fix
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('dr', start=start, end=end, dir=dir,
@@ -1289,10 +1503,20 @@ class Site:
         return listing.List(self, 'deletedrevs', 'dr', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def exturlusage(self, query, prop=None, protocol='http', namespace=None, limit=None,
-                    max_items=None, api_chunk_size=None):
+    def exturlusage(
+        self,
+        query: str,
+        prop: Optional[str] = None,
+        protocol: str = 'http',
+        namespace: Optional[Namespace] = None,
+        limit: Optional[int] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
         r"""Retrieve the list of pages that link to a particular domain or URL,
          as a generator.
+
+         API doc: https://www.mediawiki.org/wiki/API:Exturlusage
 
         This API call mirrors the Special:LinkSearch function on-wiki.
 
@@ -1319,31 +1543,68 @@ class Site:
         return listing.List(self, 'exturlusage', 'eu', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def logevents(self, type=None, prop=None, start=None, end=None,
-                  dir='older', user=None, title=None, limit=None, action=None,
-                  max_items=None, api_chunk_size=None):
-        """Retrieve logevents as a generator."""
-        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
+    def logevents(
+        self,
+        type: Optional[str] = None,
+        prop: Optional[str] = None,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        dir: str = 'older',
+        user: Optional[str] = None,
+        title: Optional[str] = None,
+        limit: Optional[int] = None,
+        action: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        Retrieve logevents as a generator.
+
+        API doc: https://www.mediawiki.org/wiki/API:Logevents
+        """
         kwargs = dict(listing.List.generate_kwargs('le', prop=prop, type=type,
                                                    start=start, end=end, dir=dir,
                                                    user=user, title=title, action=action))
         return listing.List(self, 'logevents', 'le', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def checkuserlog(self, user=None, target=None, limit=None, dir='older',
-                     start=None, end=None, max_items=None, api_chunk_size=10):
+    def checkuserlog(
+        self,
+        user: Optional[str] = None,
+        target: Optional[str] = None,
+        limit: Optional[int] = None,
+        dir: str = 'older',
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = 10
+    ) -> listing.NestedList:
         """Retrieve checkuserlog items as a generator."""
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('cul', target=target, start=start,
                                                    end=end, dir=dir, user=user))
-        return listing.NestedList('entries', self, 'checkuserlog', 'cul',
-                                  max_items=max_items, api_chunk_size=api_chunk_size,
-                                  **kwargs)
+        return listing.NestedList(
+            'entries',
+            self,  # type: ignore[arg-type]
+            'checkuserlog',  # type: ignore[arg-type]
+            'cul',  # type: ignore[arg-type]
+            max_items=max_items,
+            api_chunk_size=api_chunk_size,
+            **kwargs,
+        )
 
     # def protectedtitles requires 1.15
-    def random(self, namespace, limit=None, max_items=None, api_chunk_size=20):
+    def random(
+        self,
+        namespace: Namespace,
+        limit: Optional[int] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = 20
+    ) -> listing.List:
         """Retrieve a generator of random pages from a particular namespace.
+
+        API doc: https://www.mediawiki.org/wiki/API:Random
 
         max_items specifies the number of random articles retrieved.
         api_chunk_size and limit (deprecated) specify the API chunk size.
@@ -1358,10 +1619,24 @@ class Site:
         return listing.List(self, 'random', 'rn', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def recentchanges(self, start=None, end=None, dir='older', namespace=None,
-                      prop=None, show=None, limit=None, type=None, toponly=None,
-                      max_items=None, api_chunk_size=None):
-        """List recent changes to the wiki, à la Special:Recentchanges.
+    def recentchanges(
+        self,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        dir: str = 'older',
+        namespace: Optional[Namespace] = None,
+        prop: Optional[str] = None,
+        show: Optional[str] = None,
+        limit: Optional[int] = None,
+        type: Optional[str] = None,
+        toponly: Optional[bool] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
+        """
+        List recent changes to the wiki, à la Special:Recentchanges.
+
+        API doc: https://www.mediawiki.org/wiki/API:Recentchanges
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('rc', start=start, end=end, dir=dir,
@@ -1371,7 +1646,9 @@ class Site:
         return listing.List(self, 'recentchanges', 'rc', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def revisions(self, revids, prop='ids|timestamp|flags|comment|user'):
+    def revisions(
+        self, revids: List[int], prop: str = 'ids|timestamp|flags|comment|user'
+    ) -> List[Dict[str, Any]]:
         """Get data about a list of revisions.
 
         See also the `Page.revisions()` method.
@@ -1384,8 +1661,8 @@ class Site:
             ...     print(revision['*'])
 
         Args:
-            revids (list): A list of (max 50) revisions.
-            prop (str): Which properties to get for each revision.
+            revids: A list of (max 50) revisions.
+            prop: Which properties to get for each revision.
 
         Returns:
             A list of revisions
@@ -1406,8 +1683,16 @@ class Site:
                 revisions.append(revision)
         return revisions
 
-    def search(self, search, namespace='0', what=None, redirects=False, limit=None,
-               max_items=None, api_chunk_size=None):
+    def search(
+        self,
+        search: str,
+        namespace: Namespace = '0',
+        what: Optional[str] = None,
+        redirects: bool = False,
+        limit: Optional[int] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
         """Perform a full text search.
 
         API doc: https://www.mediawiki.org/wiki/API:Search
@@ -1417,17 +1702,17 @@ class Site:
             ...     print(result.get('title'))
 
         Args:
-            search (str): The query string
-            namespace (int): The namespace to search (default: 0)
-            what (str): Search scope: 'text' for fulltext, or 'title' for titles only.
-                        Depending on the search backend,
-                        both options may not be available.
-                        For instance
-                        `CirrusSearch <https://www.mediawiki.org/wiki/Help:CirrusSearch>`_
-                        doesn't support 'title', but instead provides an "intitle:"
-                        query string filter.
-            redirects (bool): Include redirect pages in the search
-                              (option removed in MediaWiki 1.23).
+            search: The query string
+            namespace: The namespace to search (default: 0)
+            what: Search scope: 'text' for fulltext, or 'title' for titles only.
+                  Depending on the search backend,
+                  both options may not be available.
+                  For instance
+                  `CirrusSearch <https://www.mediawiki.org/wiki/Help:CirrusSearch>`_
+                  doesn't support 'title', but instead provides an "intitle:"
+                  query string filter.
+            redirects: Include redirect pages in the search
+                       (option removed in MediaWiki 1.23).
 
         Returns:
             mwclient.listings.List: Search results iterator
@@ -1440,9 +1725,20 @@ class Site:
         return listing.List(self, 'search', 'sr', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def usercontributions(self, user, start=None, end=None, dir='older', namespace=None,
-                          prop=None, show=None, limit=None, uselang=None, max_items=None,
-                          api_chunk_size=None):
+    def usercontributions(
+        self,
+        user: str,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        dir: str = 'older',
+        namespace: Optional[Namespace] = None,
+        prop: Optional[str] = None,
+        show: Optional[str] = None,
+        limit: Optional[int] = None,
+        uselang: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
         """
         List the contributions made by a given user to the wiki.
 
@@ -1455,7 +1751,11 @@ class Site:
         return listing.List(self, 'usercontribs', 'uc', max_items=max_items,
                             api_chunk_size=api_chunk_size, uselang=uselang, **kwargs)
 
-    def users(self, users, prop='blockinfo|groups|editcount'):
+    def users(
+        self,
+        users: Iterable[str],
+        prop: str = 'blockinfo|groups|editcount'
+    ) -> listing.List:
         """
         Get information about a list of users.
 
@@ -1464,8 +1764,19 @@ class Site:
 
         return listing.List(self, 'users', 'us', ususers='|'.join(users), usprop=prop)
 
-    def watchlist(self, allrev=False, start=None, end=None, namespace=None, dir='older',
-                  prop=None, show=None, limit=None, max_items=None, api_chunk_size=None):
+    def watchlist(
+        self,
+        allrev: bool = False,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        namespace: Optional[Namespace] = None,
+        dir: str = 'older',
+        prop: Optional[str] = None,
+        show: Optional[str] = None,
+        limit: Optional[int] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> listing.List:
         """
         List the pages on the current user's watchlist.
 
@@ -1481,16 +1792,18 @@ class Site:
         return listing.List(self, 'watchlist', 'wl', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
-    def expandtemplates(self, text, title=None, generatexml=False):
+    def expandtemplates(
+        self, text: str, title: Optional[str] = None, generatexml: bool = False
+    ) -> Any:
         """
         Takes wikitext (text) and expands templates.
 
         API doc: https://www.mediawiki.org/wiki/API:Expandtemplates
 
         Args:
-            text (str): Wikitext to convert.
-            title (str): Title of the page.
-            generatexml (bool): Generate the XML parse tree. Defaults to `False`.
+            text: Wikitext to convert.
+            title: Title of the page.
+            generatexml: Generate the XML parse tree. Defaults to `False`.
         """
 
         kwargs = {}
@@ -1507,14 +1820,14 @@ class Site:
         else:
             return result['expandtemplates']['*']
 
-    def ask(self, query, title=None):
+    def ask(self, query: str, title: Optional[str] = None) -> Iterable[Dict[str, Any]]:
         """
         Ask a query against Semantic MediaWiki.
 
         API doc: https://semantic-mediawiki.org/wiki/Ask_API
 
         Args:
-            query (str): The SMW query to be executed.
+            query: The SMW query to be executed.
 
         Returns:
             Generator for retrieving all search results, with each answer as a dictionary.
@@ -1529,16 +1842,16 @@ class Site:
             >>>         print(title)
             >>>         print(data)
         """
-        kwargs = {}
+        kwargs = {}  # type: Dict[str, Any]
         if title is not None:
             kwargs['title'] = title
 
-        offset = 0
+        offset = 0  # type: Optional[int]
         while offset is not None:
             results = self.raw_api('ask', query=f'{query}|offset={offset}',
                                    http_method='GET', **kwargs)
             self.handle_api_result(results)  # raises APIError on error
-            offset = results.get('query-continue-offset')
+            offset = cast(Optional[int], results.get('query-continue-offset'))
             answers = results['query'].get('results', [])
 
             if isinstance(answers, dict):

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1647,7 +1647,9 @@ class Site:
                             api_chunk_size=api_chunk_size, **kwargs)
 
     def revisions(
-        self, revids: List[int], prop: str = 'ids|timestamp|flags|comment|user'
+        self,
+        revids: List[Union[int, str]],
+        prop: str = 'ids|timestamp|flags|comment|user',
     ) -> List[Dict[str, Any]]:
         """Get data about a list of revisions.
 
@@ -1794,7 +1796,7 @@ class Site:
 
     def expandtemplates(
         self, text: str, title: Optional[str] = None, generatexml: bool = False
-    ) -> Any:
+    ) -> Union[str, Tuple[str, str]]:
         """
         Takes wikitext (text) and expands templates.
 
@@ -1816,9 +1818,9 @@ class Site:
         result = self.post('expandtemplates', text=text, **kwargs)
 
         if generatexml:
-            return result['expandtemplates']['*'], result['parsetree']['*']
+            return str(result['expandtemplates']['*']), str(result['parsetree']['*'])
         else:
-            return result['expandtemplates']['*']
+            return str(result['expandtemplates']['*'])
 
     def ask(self, query: str, title: Optional[str] = None) -> Iterable[Dict[str, Any]]:
         """

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -301,7 +301,7 @@ class Site:
         version_tuple = tuple(
             int(segment) if segment.isdigit() else segment
             for segment in _split_version(version)
-        )
+        )  # type: Tuple[Union[int, str], ...]
 
         if len(version_tuple) < 2:
             raise errors.MediaWikiVersionError(f'Unknown MediaWiki {".".join(version)}')
@@ -1061,7 +1061,7 @@ class Site:
             content_size = file.seek(0, 2)
             file.seek(0)
 
-            if (self.require(1, 20, raise_error=False)  # type: ignore[index]
+            if (self.require(1, 20, raise_error=False)
                     and content_size > self.chunk_size):
                 return self.chunk_upload(file, filename, ignore, comment, text)
 
@@ -1081,7 +1081,7 @@ class Site:
 
         # sessionkey was renamed to filekey in MediaWiki 1.18
         # https://phabricator.wikimedia.org/rMW5f13517e36b45342f228f3de4298bb0fe186995d
-        if not self.require(1, 18, raise_error=False):  # type: ignore[index]
+        if not self.require(1, 18, raise_error=False):
             predata['sessionkey'] = filekey
         else:
             predata['filekey'] = filekey
@@ -1589,9 +1589,9 @@ class Site:
                                                    end=end, dir=dir, user=user))
         return listing.NestedList(
             'entries',
-            self,  # type: ignore[arg-type]
-            'checkuserlog',  # type: ignore[arg-type]
-            'cul',  # type: ignore[arg-type]
+            self,
+            'checkuserlog',
+            'cul',
             max_items=max_items,
             api_chunk_size=api_chunk_size,
             **kwargs,

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -13,7 +13,7 @@ from requests_oauthlib import OAuth1
 import mwclient.errors as errors
 import mwclient.listing as listing
 from mwclient.sleep import Sleeper, Sleepers
-from mwclient.types import Namespace, VersionTuple
+from mwclient.types import Cookies, Namespace, VersionTuple
 from mwclient.util import parse_timestamp, read_in_chunks, handle_limit
 
 __version__ = '0.11.0'
@@ -776,7 +776,7 @@ class Site:
         self,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        cookies: Optional[Mapping[str, str]] = None,
+        cookies: Optional[Cookies] = None,
         domain: Optional[str] = None
     ) -> None:
         """
@@ -852,9 +852,7 @@ class Site:
 
         self.site_init()
 
-    def clientlogin(
-        self, cookies: Optional[Mapping[str, str]] = None, **kwargs: Any
-    ) -> Any:
+    def clientlogin(self, cookies: Optional[Cookies] = None, **kwargs: Any) -> Any:
         """
         Login to the wiki using a username and password. The method returns
         True if it's a success or the returned response if it's a multi-steps

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -13,7 +13,7 @@ from requests_oauthlib import OAuth1
 import mwclient.errors as errors
 import mwclient.listing as listing
 from mwclient.sleep import Sleeper, Sleepers
-from mwclient.types import Namespace
+from mwclient.types import Namespace, VersionTuple
 from mwclient.util import parse_timestamp, read_in_chunks, handle_limit
 
 __version__ = '0.11.0'
@@ -166,7 +166,7 @@ class Site:
         self.groups = []  # type: List[str]  # Groups current user is in
         self.rights = []  # type: List[str]  # Rights current user has
         self.tokens = {}  # type: Dict[str, str]  # Edit tokens of the current user
-        self.version = None  # type: Union[Tuple[int, ...], Tuple[int, str], None]
+        self.version = None  # type: Optional[VersionTuple]
 
         self.namespaces = self.default_namespaces  # type: Dict[int, str]
 
@@ -256,7 +256,7 @@ class Site:
     @staticmethod
     def version_tuple_from_generator(
         string: str, prefix: str = 'MediaWiki '
-    ) -> Union[Tuple[int, ...], Tuple[int, str]]:
+    ) -> VersionTuple:
         """Return a version tuple from a MediaWiki Generator string.
 
         Example:

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1,10 +1,9 @@
-import io
 import json
 import logging
 import warnings
 from collections import OrderedDict
 from typing import Optional, Callable, Union, Mapping, Any, MutableMapping, List, Dict, \
-    Tuple, cast, Iterable, BinaryIO, TextIO, Iterator
+    Tuple, cast, Iterable, BinaryIO, Iterator
 
 import requests
 from requests.auth import HTTPBasicAuth, AuthBase
@@ -494,9 +493,7 @@ class Site:
         self,
         script: str,
         data: Mapping[str, Any],
-        files: Optional[
-            Mapping[str, Union[io.BytesIO, Tuple[str, io.BufferedReader]]]
-        ] = None,
+        files: Optional[Mapping[str, Union[BinaryIO, Tuple[str, BinaryIO]]]] = None,
         retry_on_error: bool = True,
         http_method: str = 'POST'
     ) -> str:
@@ -978,7 +975,7 @@ class Site:
 
     def upload(
         self,
-        file: Union[str, BinaryIO, TextIO, None] = None,
+        file: Union[str, BinaryIO, None] = None,
         filename: Optional[str] = None,
         description: str = '',
         ignore: bool = False,
@@ -1049,9 +1046,9 @@ class Site:
             if not hasattr(file, 'read'):
                 file = open(file, 'rb')
 
-            # Narrowing the type of file from Union[str, io.BufferedReader] to just
-            # io.BufferedReader, since we know it's not a string at this point.
-            file = cast(io.BufferedReader, file)
+            # Narrowing the type of file from Union[str, BinaryIO, None]
+            # to BinaryIO, since we know it's not a str at this point.
+            file = cast(BinaryIO, file)
 
             content_size = file.seek(0, 2)
             file.seek(0)
@@ -1115,7 +1112,7 @@ class Site:
 
     def chunk_upload(
         self,
-        file: io.BufferedReader,
+        file: BinaryIO,
         filename: str,
         ignorewarnings: bool,
         comment: str,

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -545,7 +545,7 @@ class Site:
         url = f'{scheme}://{host}{self.path}{script}{self.ext}'
 
         while True:
-            toraise = None
+            toraise = None  # type: Optional[Union[requests.RequestException, str]]
             wait_time = 0
             args = {'files': files, 'headers': headers}  # type: Dict[str, Any]
             for k, v in self.requests.items():
@@ -589,7 +589,7 @@ class Site:
                 if not retry_on_error:
                     raise
                 log.warning('Connection error. Retrying in a moment.')
-                toraise = err  # type: ignore[assignment]
+                toraise = err
                 # proceed to the sleep
 
             # all retry paths come here
@@ -598,8 +598,8 @@ class Site:
             except errors.MaximumRetriesExceeded:
                 if toraise == "stream":
                     stream.raise_for_status()
-                elif toraise:
-                    raise toraise  # type: ignore[misc]
+                elif toraise and isinstance(toraise, BaseException):
+                    raise toraise
                 else:
                     raise
 

--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -1,3 +1,9 @@
+from typing import Any, TYPE_CHECKING, Optional, cast
+
+if TYPE_CHECKING:
+    import mwclient.page
+
+
 class MwClientError(RuntimeError):
     """Base class for all mwclient errors."""
     pass
@@ -27,7 +33,7 @@ class APIError(MwClientError):
         kwargs (Optional[Any]): Additional information.
     """
 
-    def __init__(self, code, info, kwargs):
+    def __init__(self, code: Optional[str], info: str, kwargs: Optional[Any]) -> None:
         self.code = code
         self.info = info
         super().__init__(code, info, kwargs)
@@ -58,12 +64,17 @@ class ProtectedPageError(EditError, InsufficientPermission):
         info (Optional[str]): The error message returned by the API.
     """
 
-    def __init__(self, page, code=None, info=None):
+    def __init__(
+        self,
+        page: 'mwclient.page.Page',
+        code: Optional[str] = None,
+        info: Optional[str] = None
+    ) -> None:
         self.page = page
         self.code = code
         self.info = info
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.info is not None:
             return self.info
         return 'You do not have the "edit" right.'
@@ -79,10 +90,10 @@ class FileExists(EditError):
         file_name (str): The name of the file that already exists.
     """
 
-    def __init__(self, file_name):
+    def __init__(self, file_name: str) -> None:
         self.file_name = file_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f'The file "{self.file_name}" already exists. '
             f'Set ignore=True to overwrite it.'
@@ -99,7 +110,9 @@ class LoginError(MwClientError):
         info (str): The error message returned by the API.
     """
 
-    def __init__(self, site, code, info):
+    def __init__(
+        self, site: 'mwclient.client.Site', code: Optional[str], info: str
+    ) -> None:
         super().__init__(
             site,
             {'result': code, 'reason': info}  # For backwards-compability
@@ -108,7 +121,7 @@ class LoginError(MwClientError):
         self.code = code
         self.info = info
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.info
 
 
@@ -126,15 +139,15 @@ class OAuthAuthorizationError(LoginError):
 
 class AssertUserFailedError(MwClientError):
     """Raised when the user assertion fails."""
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             'By default, mwclient protects you from accidentally editing '
             'without being logged in. If you actually want to edit without '
             'logging in, you can set force_login on the Site object to False.'
         )
 
-    def __str__(self):
-        return self.args[0]
+    def __str__(self) -> str:
+        return cast(str, self.args[0])
 
 
 class EmailError(MwClientError):
@@ -154,7 +167,7 @@ class InvalidResponse(MwClientError):
         response_text (str): The response text from the server.
     """
 
-    def __init__(self, response_text=None):
+    def __init__(self, response_text: Optional[str] = None) -> None:
         super().__init__((
             'Did not get a valid JSON response from the server. Check that '
             'you used the correct hostname. If you did, the server might '
@@ -163,8 +176,8 @@ class InvalidResponse(MwClientError):
         )
         self.response_text = response_text
 
-    def __str__(self):
-        return self.args[0]
+    def __str__(self) -> str:
+        return cast(str, self.args[0])
 
 
 class InvalidPageTitle(MwClientError):

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -159,8 +159,8 @@ class List:
 
 
 class NestedList(List):
-    def __init__(self, nested_param: str, *args: Tuple[str, Any], **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+    def __init__(self, nested_param: str, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.nested_param = nested_param
 
     def set_iter(self, data: Mapping[str, Any]) -> None:

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -1,6 +1,11 @@
-from mwclient.util import parse_timestamp, handle_limit
-import mwclient.page
+from typing import (  # noqa: F401
+    Optional, Tuple, Any, Union, Iterator, Mapping, Iterable, Type
+)
+
 import mwclient.image
+import mwclient.page
+from mwclient.types import Namespace
+from mwclient.util import parse_timestamp, handle_limit
 
 
 class List:
@@ -18,9 +23,19 @@ class List:
     to its misleading name.
     """
 
-    def __init__(self, site, list_name, prefix,
-                 limit=None, return_values=None, max_items=None,
-                 api_chunk_size=None, *args, **kwargs):
+    def __init__(
+        self,
+        site: 'mwclient.client.Site',
+        list_name: str,
+        prefix: str,
+        limit: Optional[int] = None,
+        return_values: Union[str, Tuple[str, ...], None] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None,
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> None:
+        # NOTE: Fix limit
         self.site = site
         self.list_name = list_name
         self.generator = 'list'
@@ -41,16 +56,16 @@ class List:
         self.count = 0
         self.max_items = max_items
 
-        self._iter = iter(range(0))
+        self._iter = iter(range(0))  # type: Iterator[Any]
 
         self.last = False
         self.result_member = list_name
         self.return_values = return_values
 
-    def __iter__(self):
+    def __iter__(self) -> 'List':
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         if self.max_items is not None:
             if self.count >= self.max_items:
                 raise StopIteration
@@ -80,7 +95,7 @@ class List:
             return item[self.return_values]
         return item
 
-    def load_chunk(self):
+    def load_chunk(self) -> None:
         """Query a new chunk of data
 
         If the query is empty, `raise StopIteration`.
@@ -113,7 +128,7 @@ class List:
         else:
             self.last = True
 
-    def set_iter(self, data):
+    def set_iter(self, data: Mapping[str, Any]) -> None:
         """Set `self._iter` to the API response `data`."""
         if self.result_member not in data['query']:
             self._iter = iter(range(0))
@@ -122,31 +137,33 @@ class List:
         else:
             self._iter = iter(data['query'][self.result_member].values())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} object '{self.list_name}' for {self.site}>"
 
     @staticmethod
-    def generate_kwargs(_prefix, *args, **kwargs):
+    def generate_kwargs(
+        _prefix: str, *args: Tuple[str, Any], **kwargs: Any
+    ) -> Iterable[Tuple[str, Any]]:
         kwargs.update(args)
         for key, value in kwargs.items():
             if value is not None and value is not False:
                 yield _prefix + key, value
 
     @staticmethod
-    def get_prefix(prefix, generator=False):
+    def get_prefix(prefix: str, generator: bool = False) -> str:
         return ('g' if generator else '') + prefix
 
     @staticmethod
-    def get_list(generator=False):
+    def get_list(generator: bool = False) -> Union[Type['GeneratorList'], Type['List']]:
         return GeneratorList if generator else List
 
 
 class NestedList(List):
-    def __init__(self, nested_param, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, nested_param: str, *args: Tuple[str, Any], **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
         self.nested_param = nested_param
 
-    def set_iter(self, data):
+    def set_iter(self, data: Mapping[str, Any]) -> None:
         self._iter = iter(data['query'][self.result_member][self.nested_param])
 
 
@@ -158,8 +175,17 @@ class GeneratorList(List):
     this subclass turns the data into Page, Image or Category objects.
     """
 
-    def __init__(self, site, list_name, prefix, *args, **kwargs):
-        super().__init__(site, list_name, prefix, *args, **kwargs)
+    def __init__(
+        self,
+        site: 'mwclient.client.Site',
+        list_name: str,
+        prefix: str,
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> None:
+        super().__init__(
+            site, list_name, prefix, *args, **kwargs  # type: ignore[arg-type]
+        )
 
         self.args['g' + self.prefix + 'limit'] = self.args[self.prefix + 'limit']
         del self.args[self.prefix + 'limit']
@@ -172,7 +198,7 @@ class GeneratorList(List):
 
         self.page_class = mwclient.page.Page
 
-    def __next__(self):
+    def __next__(self) -> Union['mwclient.page.Page', 'mwclient.image.Image', 'Category']:
         info = super().__next__()
         if info['ns'] == 14:
             return Category(self.site, '', info)
@@ -180,7 +206,7 @@ class GeneratorList(List):
             return mwclient.image.Image(self.site, '', info)
         return mwclient.page.Page(self.site, '', info)
 
-    def load_chunk(self):
+    def load_chunk(self) -> None:
         # Put this here so that the constructor does not fail
         # on uninitialized sites
         self.args['iiprop'] = 'timestamp|user|comment|url|size|sha1|metadata|archivename'
@@ -203,7 +229,13 @@ class Category(mwclient.page.Page, GeneratorList):
             members to list.
     """
 
-    def __init__(self, site, name, info=None, namespace=None):
+    def __init__(
+        self,
+        site: 'mwclient.client.Site',
+        name: str,
+        info: Optional[Mapping[str, Any]] = None,
+        namespace: Optional[Namespace] = None
+    ) -> None:
         mwclient.page.Page.__init__(self, site, name, info)
         kwargs = {}
         kwargs['gcmtitle'] = self.name
@@ -211,11 +243,19 @@ class Category(mwclient.page.Page, GeneratorList):
             kwargs['gcmnamespace'] = namespace
         GeneratorList.__init__(self, site, 'categorymembers', 'cm', **kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} object '{self.name}' for {self.site}>"
 
-    def members(self, prop='ids|title', namespace=None, sort='sortkey',
-                dir='asc', start=None, end=None, generator=True):
+    def members(
+        self,
+        prop: str = 'ids|title',
+        namespace: Optional[Namespace] = None,
+        sort: str = 'sortkey',
+        dir: str = 'asc',
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        generator: bool = True
+    ) -> 'List':
         prefix = self.get_prefix('cm', generator)
         kwargs = dict(self.generate_kwargs(prefix, prop=prop, namespace=namespace,
                                            sort=sort, dir=dir, start=start, end=end,
@@ -225,8 +265,15 @@ class Category(mwclient.page.Page, GeneratorList):
 
 class PageList(GeneratorList):
 
-    def __init__(self, site, prefix=None, start=None, namespace=0, redirects='all',
-                 end=None):
+    def __init__(
+        self,
+        site: 'mwclient.client.Site',
+        prefix: Optional[str] = None,
+        start: Optional[str] = None,
+        namespace: int = 0,
+        redirects: str = 'all',
+        end: Optional[str] = None
+    ):
         self.namespace = namespace
 
         kwargs = {}
@@ -240,10 +287,14 @@ class PageList(GeneratorList):
         super().__init__(site, 'allpages', 'ap', gapnamespace=str(namespace),
                          gapfilterredir=redirects, **kwargs)
 
-    def __getitem__(self, name):
+    def __getitem__(
+        self, name: str
+    ) -> Union['mwclient.page.Page', 'mwclient.image.Image', 'Category']:
         return self.get(name, None)
 
-    def get(self, name, info=()):
+    def get(
+        self, name: str, info: Optional[Mapping[str, Any]] = None
+    ) -> Union['mwclient.page.Page', 'mwclient.image.Image', 'Category']:
         """Return the page of name `name` as an object.
 
         If self.namespace is not zero, use {namespace}:{name} as the
@@ -269,16 +320,16 @@ class PageList(GeneratorList):
             6: mwclient.image.Image,
         }.get(namespace, mwclient.page.Page)
 
-        return cls(self.site, full_page_name, info)
+        return cls(self.site, full_page_name, info)  # type: ignore[no-any-return]
 
-    def guess_namespace(self, name):
+    def guess_namespace(self, name: str) -> int:
         """Guess the namespace from name
 
         If name starts with any of the site's namespaces' names or
         default_namespaces, use that.  Else, return zero.
 
         Args:
-            name (str): The pagename as a string (having `.startswith`)
+            name: The pagename as a string (having `.startswith`)
 
         Returns:
             The id of the guessed namespace or zero.
@@ -294,12 +345,26 @@ class PageList(GeneratorList):
 
 class PageProperty(List):
 
-    def __init__(self, page, prop, prefix, *args, **kwargs):
-        super().__init__(page.site, prop, prefix, titles=page.name, *args, **kwargs)
+    def __init__(
+        self,
+        page: 'mwclient.page.Page',
+        prop: str,
+        prefix: str,
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> None:
+        super().__init__(
+            page.site,
+            prop,
+            prefix,
+            titles=page.name,
+            *args,  # type: ignore[arg-type]
+            **kwargs,
+        )
         self.page = page
         self.generator = 'prop'
 
-    def set_iter(self, data):
+    def set_iter(self, data: Mapping[str, Any]) -> None:
         for page in data['query']['pages'].values():
             if page['title'] == self.page.name:
                 self._iter = iter(page.get(self.list_name, ()))
@@ -309,14 +374,21 @@ class PageProperty(List):
 
 class PagePropertyGenerator(GeneratorList):
 
-    def __init__(self, page, prop, prefix, *args, **kwargs):
+    def __init__(
+        self,
+        page: 'mwclient.page.Page',
+        prop: str,
+        prefix: str,
+        *args: Tuple[str, Any],
+        **kwargs: Any
+    ) -> None:
         super().__init__(page.site, prop, prefix, titles=page.name, *args, **kwargs)
         self.page = page
 
 
 class RevisionsIterator(PageProperty):
 
-    def load_chunk(self):
+    def load_chunk(self) -> None:
         if 'rvstartid' in self.args and 'rvstart' in self.args:
             del self.args['rvstart']
         return super().load_chunk()

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -1,5 +1,7 @@
 import time
-from typing import Optional, Mapping, Any, cast, Dict, Union, Tuple  # noqa: F401
+from typing import (  # noqa: F401
+    Optional, Mapping, Any, cast, Dict, Union, Tuple, Iterable, List
+)
 
 import mwclient.errors
 import mwclient.listing
@@ -38,7 +40,7 @@ class Page:
         site: 'mwclient.client.Site',
         name: Union[int, str, 'Page'],
         info: Optional[Mapping[str, Any]] = None,
-        extra_properties: Optional[Mapping[str, Any]] = None
+        extra_properties: Optional[Mapping[str, Iterable[Tuple[str, str]]]] = None
     ) -> None:
         if type(name) is type(self):
             self.__dict__.update(name.__dict__)
@@ -49,7 +51,7 @@ class Page:
         if not info:
             if extra_properties:
                 prop = 'info|' + '|'.join(extra_properties.keys())
-                extra_props = []
+                extra_props = []  # type: List[Tuple[str, str]]
                 for extra_prop in extra_properties.values():
                     extra_props.extend(extra_prop)
             else:

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -1,7 +1,10 @@
 import time
-from mwclient.util import parse_timestamp, handle_limit
-import mwclient.listing
+from typing import Optional, Mapping, Any, cast, Dict, Union, Tuple  # noqa: F401
+
 import mwclient.errors
+import mwclient.listing
+from mwclient.types import Namespace
+from mwclient.util import parse_timestamp, handle_limit
 
 
 class Page:
@@ -30,13 +33,18 @@ class Page:
         ... })
     """
 
-    def __init__(self, site, name, info=None, extra_properties=None):
+    def __init__(
+        self,
+        site: 'mwclient.client.Site',
+        name: Union[int, str, 'Page'],
+        info: Optional[Mapping[str, Any]] = None,
+        extra_properties: Optional[Mapping[str, Any]] = None
+    ) -> None:
         if type(name) is type(self):
             self.__dict__.update(name.__dict__)
             return
         self.site = site
-        self.name = name
-        self._textcache = {}
+        self._textcache = {}  # type: Dict[int, str]
 
         if not info:
             if extra_properties:
@@ -46,7 +54,7 @@ class Page:
                     extra_props.extend(extra_prop)
             else:
                 prop = 'info'
-                extra_props = ()
+                extra_props = []
 
             if type(name) is int:
                 info = self.site.get('query', prop=prop, pageids=name,
@@ -55,6 +63,8 @@ class Page:
                 info = self.site.get('query', prop=prop, titles=name,
                                      inprop='protection', *extra_props)
             info = next(iter(info['query']['pages'].values()))
+
+        info = cast(Mapping[str, Any], info)
         self._info = info
 
         if 'invalid' in info:
@@ -85,10 +95,10 @@ class Page:
         self.pagelanguage = info.get('pagelanguage', None)
         self.restrictiontypes = info.get('restrictiontypes', None)
 
-        self.last_rev_time = None
-        self.edit_time = None
+        self.last_rev_time = None  # type: Optional[time.struct_time]
+        self.edit_time = None  # type: Optional[time.struct_time]
 
-    def redirects_to(self):
+    def redirects_to(self) -> Optional['Page']:
         """ Get the redirect target page, or None if the page is not a redirect."""
         info = self.site.get('query', prop='pageprops', titles=self.name, redirects='')
         if 'redirects' in info['query']:
@@ -99,7 +109,7 @@ class Page:
         else:
             return None
 
-    def resolve_redirect(self):
+    def resolve_redirect(self) -> 'Page':
         """ Get the redirect target page, or the current page if its not a redirect."""
         target_page = self.redirects_to()
         if target_page is None:
@@ -107,17 +117,17 @@ class Page:
         else:
             return target_page
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} object '{self.name}' for {self.site}>"
 
     @staticmethod
-    def strip_namespace(title):
+    def strip_namespace(title: str) -> str:
         if title[0] == ':':
             title = title[1:]
         return title[title.find(':') + 1:]
 
     @staticmethod
-    def normalize_title(title):
+    def normalize_title(title: str) -> str:
         # TODO: Make site dependent
         title = title.strip()
         if title[0] == ':':
@@ -126,7 +136,7 @@ class Page:
         title = title.replace(' ', '_')
         return title
 
-    def can(self, action):
+    def can(self, action: str) -> bool:
         """Check if the current user has the right to carry out some action
         with the current page.
 
@@ -141,10 +151,16 @@ class Page:
 
         return level in self.site.rights
 
-    def get_token(self, type, force=False):
+    def get_token(self, type: str, force: bool = False) -> str:
         return self.site.get_token(type, force, title=self.name)
 
-    def text(self, section=None, expandtemplates=False, cache=True, slot='main'):
+    def text(
+        self,
+        section: Union[int, str, None] = None,
+        expandtemplates: bool = False,
+        cache: bool = True,
+        slot: str = 'main'
+    ) -> Any:
         """Get the current wikitext of the page, or of a specific section.
 
         If the page does not exist, an empty string is returned. By
@@ -154,9 +170,9 @@ class Page:
         lives as long as the instance does.
 
         Args:
-            section (int): Section number, to only get text from a single section.
-            expandtemplates (bool): Expand templates (default: `False`)
-            cache (bool): Use in-memory caching (default: `True`)
+            section: Section number, to only get text from a single section.
+            expandtemplates: Expand templates (default: `False`)
+            cache: Use in-memory caching (default: `True`)
         """
 
         if not self.can('read'):
@@ -196,28 +212,52 @@ class Page:
             self._textcache[key] = text
         return text
 
-    def save(self, *args, **kwargs):
+    def save(self, *args: Tuple[str, Any], **kwargs: Any) -> Any:
         """Alias for edit, for maintaining backwards compatibility."""
-        return self.edit(*args, **kwargs)
+        return self.edit(*args, **kwargs)  # type: ignore[arg-type]
 
-    def edit(self, text, summary='', minor=False, bot=True, section=None, **kwargs):
+    def edit(
+        self,
+        text: str,
+        summary: str = '',
+        minor: bool = False,
+        bot: bool = True,
+        section: Optional[str] = None,
+        **kwargs: Any
+    ) -> Any:
         """Update the text of a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, text=text, **kwargs)
 
-    def append(self, text, summary='', minor=False, bot=True, section=None,
-               **kwargs):
+    def append(
+        self,
+        text: str,
+        summary: str = '',
+        minor: bool = False,
+        bot: bool = True,
+        section: Optional[str] = None,
+        **kwargs: Any
+    ) -> Any:
         """Append text to a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, appendtext=text, **kwargs)
 
-    def prepend(self, text, summary='', minor=False, bot=True, section=None,
-                **kwargs):
+    def prepend(
+        self,
+        text: str,
+        summary: str = '',
+        minor: bool = False,
+        bot: bool = True,
+        section: Optional[str] = None,
+        **kwargs: Any
+    ) -> Any:
         """Prepend text to a section or the whole page by performing an edit operation.
         """
         return self._edit(summary, minor, bot, section, prependtext=text, **kwargs)
 
-    def _edit(self, summary, minor, bot, section, **kwargs):
+    def _edit(
+        self, summary: str, minor: bool, bot: bool, section: Optional[str], **kwargs: Any
+    ) -> Any:
         if not self.site.logged_in and self.site.force_login:
             raise mwclient.errors.AssertUserFailedError()
         if self.site.blocked:
@@ -244,7 +284,7 @@ class Page:
         if self.site.force_login:
             data['assert'] = 'user'
 
-        def do_edit():
+        def do_edit() -> Any:
             result = self.site.post('edit', title=self.name, summary=summary,
                                     token=self.get_token('edit'),
                                     **data)
@@ -260,8 +300,8 @@ class Page:
                 self.get_token('edit', force=True)
                 try:
                     result = do_edit()
-                except mwclient.errors.APIError as e:
-                    self.handle_edit_error(e, summary)
+                except mwclient.errors.APIError as e2:
+                    self.handle_edit_error(e2, summary)
             else:
                 self.handle_edit_error(e, summary)
 
@@ -279,7 +319,7 @@ class Page:
         self._textcache = {}
         return result['edit']
 
-    def handle_edit_error(self, e, summary):
+    def handle_edit_error(self, e: 'mwclient.errors.APIError', summary: str) -> None:
         if e.code == 'editconflict':
             raise mwclient.errors.EditError(self, summary, e.info)
         elif e.code in {'protectedtitle', 'cantcreate', 'cantcreate-anon',
@@ -293,7 +333,7 @@ class Page:
         else:
             raise e
 
-    def touch(self):
+    def touch(self) -> None:
         """Perform a "null edit" on the page to update the wiki's cached data of it.
         This is useful in contrast to purge when needing to update stored data on a wiki,
         for example Semantic MediaWiki properties or Cargo table values, since purge
@@ -303,8 +343,15 @@ class Page:
             return
         self.append('')
 
-    def move(self, new_title, reason='', move_talk=True, no_redirect=False,
-             move_subpages=False, ignore_warnings=False):
+    def move(
+        self,
+        new_title: str,
+        reason: str = '',
+        move_talk: bool = True,
+        no_redirect: bool = False,
+        move_subpages: bool = False,
+        ignore_warnings: bool = False
+    ) -> Any:
         """Move (rename) page to new_title.
 
         If user account is an administrator, specify no_redirect as True to not
@@ -313,6 +360,7 @@ class Page:
         If user does not have permission to move page, an InsufficientPermission
         exception is raised.
 
+        API doc: https://www.mediawiki.org/wiki/API:Move
         """
         if not self.can('move'):
             raise mwclient.errors.InsufficientPermission(self)
@@ -330,12 +378,19 @@ class Page:
                                 token=self.get_token('move'), reason=reason, **data)
         return result['move']
 
-    def delete(self, reason='', watch=False, unwatch=False, oldimage=False):
+    def delete(
+        self,
+        reason: str = '',
+        watch: bool = False,
+        unwatch: bool = False,
+        oldimage: Optional[str] = None
+    ) -> Any:
         """Delete page.
 
         If user does not have permission to delete page, an InsufficientPermission
         exception is raised.
 
+        API doc: https://www.mediawiki.org/wiki/API:Delete
         """
         if not self.can('delete'):
             raise mwclient.errors.InsufficientPermission(self)
@@ -352,18 +407,27 @@ class Page:
                                 reason=reason, **data)
         return result['delete']
 
-    def purge(self):
+    def purge(self) -> None:
         """Purge server-side cache of page. This will re-render templates and other
         dynamic content.
 
+        API doc: https://www.mediawiki.org/wiki/API:Purge
         """
         self.site.post('purge', titles=self.name)
 
     # def watch: requires 1.14
 
     # Properties
-    def backlinks(self, namespace=None, filterredir='all', redirect=False,
-                  limit=None, generator=True, max_items=None, api_chunk_size=None):
+    def backlinks(
+        self,
+        namespace: Optional[Namespace] = None,
+        filterredir: str = 'all',
+        redirect: bool = False,
+        limit: Optional[int] = None,
+        generator: bool = True,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> 'mwclient.listing.List':
         """List pages that link to the current page, similar to Special:Whatlinkshere.
 
         API doc: https://www.mediawiki.org/wiki/API:Backlinks
@@ -383,14 +447,16 @@ class Page:
             api_chunk_size=api_chunk_size, return_values='title', **kwargs
         )
 
-    def categories(self, generator=True, show=None):
+    def categories(
+        self, generator: bool = True, show: Optional[str] = None
+    ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List categories used on the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Categories
 
         Args:
-            generator (bool): Return generator (Default: True)
-            show (str): Set to 'hidden' to only return hidden categories
+            generator: Return generator (Default: True)
+            show: Set to 'hidden' to only return hidden categories
                 or '!hidden' to only return non-hidden ones.
 
         Returns:
@@ -411,20 +477,27 @@ class Page:
                 self, 'categories', 'cl', return_values='title', **kwargs
             )
 
-    def embeddedin(self, namespace=None, filterredir='all', limit=None, generator=True,
-                   max_items=None, api_chunk_size=None):
+    def embeddedin(
+        self,
+        namespace: Optional[Namespace] = None,
+        filterredir: str = 'all',
+        limit: Optional[int] = None,
+        generator: bool = True,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None
+    ) -> 'mwclient.listing.List':
         """List pages that transclude the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Embeddedin
 
         Args:
-            namespace (int): Restricts search to a given namespace (Default: None)
-            filterredir (str): How to filter redirects, either 'all' (default),
+            namespace Restricts search to a given namespace (Default: None)
+            filterredir: How to filter redirects, either 'all' (default),
                 'redirects' or 'nonredirects'.
-            limit (int): The API request chunk size (deprecated)
-            generator (bool): Return generator (Default: True)
-            max_items(int): The maximum number of pages to yield
-            api_chunk_size(int): The API request chunk size
+            limit: The API request chunk size (deprecated)
+            generator: Return generator (Default: True)
+            max_items: The maximum number of pages to yield
+            api_chunk_size: The API request chunk size
 
         Returns:
             mwclient.listings.List: Page iterator
@@ -440,7 +513,7 @@ class Page:
             api_chunk_size=api_chunk_size, return_values='title', **kwargs
         )
 
-    def extlinks(self):
+    def extlinks(self) -> 'mwclient.listing.PageProperty':
         """List external links from the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Extlinks
@@ -448,7 +521,9 @@ class Page:
         """
         return mwclient.listing.PageProperty(self, 'extlinks', 'el', return_values='*')
 
-    def images(self, generator=True):
+    def images(
+        self, generator: bool = True
+    ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List files/images embedded in the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Images
@@ -460,7 +535,7 @@ class Page:
             return mwclient.listing.PageProperty(self, 'images', '',
                                                  return_values='title')
 
-    def iwlinks(self):
+    def iwlinks(self) -> 'mwclient.listing.PageProperty':
         """List interwiki links from the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Iwlinks
@@ -469,7 +544,7 @@ class Page:
         return mwclient.listing.PageProperty(self, 'iwlinks', 'iw',
                                              return_values=('prefix', '*'))
 
-    def langlinks(self, **kwargs):
+    def langlinks(self, **kwargs: Any) -> 'mwclient.listing.PageProperty':
         """List interlanguage links from the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Langlinks
@@ -479,7 +554,12 @@ class Page:
                                              return_values=('lang', '*'),
                                              **kwargs)
 
-    def links(self, namespace=None, generator=True, redirects=False):
+    def links(
+        self,
+        namespace: Optional[Namespace] = None,
+        generator: bool = True,
+        redirects: bool = False
+    ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List links to other pages from the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Links
@@ -496,37 +576,50 @@ class Page:
             return mwclient.listing.PageProperty(self, 'links', 'pl',
                                                  return_values='title', **kwargs)
 
-    def revisions(self, startid=None, endid=None, start=None, end=None,
-                  dir='older', user=None, excludeuser=None, limit=None,
-                  prop='ids|timestamp|flags|comment|user',
-                  expandtemplates=False, section=None,
-                  diffto=None, slots=None, uselang=None, max_items=None,
-                  api_chunk_size=50):
+    def revisions(
+        self,
+        startid: Optional[int] = None,
+        endid: Optional[int] = None,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        dir: str = 'older',
+        user: Optional[str] = None,
+        excludeuser: Optional[str] = None,
+        limit: Optional[int] = None,
+        prop: str = 'ids|timestamp|flags|comment|user',
+        expandtemplates: bool = False,
+        section: Optional[str] = None,
+        diffto: Optional[int] = None,
+        slots: Optional[str] = None,
+        uselang: Optional[str] = None,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = 50
+    ) -> 'mwclient.listing.List':
         """List revisions of the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Revisions
 
         Args:
-            startid (int): Revision ID to start listing from.
-            endid (int): Revision ID to stop listing at.
-            start (str): Timestamp to start listing from.
-            end (str): Timestamp to end listing at.
-            dir (str): Direction to list in: 'older' (default) or 'newer'.
-            user (str): Only list revisions made by this user.
-            excludeuser (str): Exclude revisions made by this user.
-            limit (int): The API request chunk size (deprecated).
-            prop (str): Which properties to get for each revision,
+            startid: Revision ID to start listing from.
+            endid: Revision ID to stop listing at.
+            start: Timestamp to start listing from.
+            end: Timestamp to end listing at.
+            dir: Direction to list in: 'older' (default) or 'newer'.
+            user: Only list revisions made by this user.
+            excludeuser: Exclude revisions made by this user.
+            limit: The API request chunk size (deprecated).
+            prop: Which properties to get for each revision,
                 default: 'ids|timestamp|flags|comment|user'
-            expandtemplates (bool): Expand templates in rvprop=content output
-            section (int): Section number. If rvprop=content is set, only the contents
+            expandtemplates: Expand templates in rvprop=content output
+            section: Section number. If rvprop=content is set, only the contents
                 of this section will be retrieved.
-            diffto (str): Revision ID to diff each revision to. Use "prev", "next" and
+            diffto: Revision ID to diff each revision to. Use "prev", "next" and
                 "cur" for the previous, next and current revision respectively.
-            slots (str): The content slot (Mediawiki >= 1.32) to retrieve content from.
-            uselang (str): Language to use for parsed edit comments and other localized
+            slots: The content slot (Mediawiki >= 1.32) to retrieve content from.
+            uselang: Language to use for parsed edit comments and other localized
                 messages.
-            max_items(int): The maximum number of revisions to yield.
-            api_chunk_size(int): The API request chunk size (as a number of revisions).
+            max_items: The maximum number of revisions to yield.
+            api_chunk_size: The API request chunk size (as a number of revisions).
 
         Returns:
             mwclient.listings.List: Revision iterator
@@ -537,7 +630,7 @@ class Page:
             excludeuser=excludeuser, diffto=diffto, slots=slots
         ))
 
-        if self.site.version[:2] < (1, 32) and 'rvslots' in kwargs:
+        if self.site.version[:2] < (1, 32) and 'rvslots' in kwargs:  # type: ignore[index]
             # https://github.com/mwclient/mwclient/issues/199
             del kwargs['rvslots']
 
@@ -554,7 +647,9 @@ class Page:
                                                   api_chunk_size=api_chunk_size,
                                                   **kwargs)
 
-    def templates(self, namespace=None, generator=True):
+    def templates(
+        self, namespace: Optional[Namespace] = None, generator: bool = True
+    ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List templates used on the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Templates

--- a/mwclient/sleep.py
+++ b/mwclient/sleep.py
@@ -1,5 +1,7 @@
-import time
 import logging
+import time
+from typing import Callable, Optional, Any
+
 from mwclient.errors import MaximumRetriesExceeded
 
 log = logging.getLogger(__name__)
@@ -17,24 +19,30 @@ class Sleepers:
         using the `make` method.
         >>> sleeper = sleepers.make()
     Args:
-        max_retries (int): The maximum number of retries to perform.
-        retry_timeout (int): The time to sleep for each past retry.
-        callback (Callable[[int, Any], None]): A callable to be called on each retry.
+        max_retries: The maximum number of retries to perform.
+        retry_timeout: The time to sleep for each past retry.
+        callback: A callable to be called on each retry.
     Attributes:
-        max_retries (int): The maximum number of retries to perform.
-        retry_timeout (int): The time to sleep for each past retry.
-        callback (callable): A callable to be called on each retry.
+        max_retries: The maximum number of retries to perform.
+        retry_timeout: The time to sleep for each past retry.
+        callback: A callable to be called on each retry.
     """
-    def __init__(self, max_retries, retry_timeout, callback=lambda *x: None):
+
+    def __init__(
+        self,
+        max_retries: int,
+        retry_timeout: int,
+        callback: Callable[['Sleeper', int, Optional[Any]], Any] = lambda *x: None
+    ) -> None:
         self.max_retries = max_retries
         self.retry_timeout = retry_timeout
         self.callback = callback
 
-    def make(self, args=None):
+    def make(self, args: Optional[Any] = None) -> 'Sleeper':
         """
         Creates a new `Sleeper` object.
         Args:
-            args (Any): Arguments to be passed to the `callback` callable.
+            args: Arguments to be passed to the `callback` callable.
         Returns:
             Sleeper: A `Sleeper` object.
         """
@@ -48,25 +56,32 @@ class Sleeper:
     and a `MaximumRetriesExceeded` is raised. The sleeper object should be discarded
     once the operation is successful.
     Args:
-        args (Any): Arguments to be passed to the `callback` callable.
-        max_retries (int): The maximum number of retries to perform.
-        retry_timeout (int): The time to sleep for each past retry.
-        callback (callable, None]): A callable to be called on each retry.
+        args: Arguments to be passed to the `callback` callable.
+        max_retries: The maximum number of retries to perform.
+        retry_timeout: The time to sleep for each past retry.
+        callback: A callable to be called on each retry.
     Attributes:
-        args (Any): Arguments to be passed to the `callback` callable.
-        retries (int): The number of retries that have been performed.
-        max_retries (int): The maximum number of retries to perform.
-        retry_timeout (int): The time to sleep for each past retry.
-        callback (callable): A callable to be called on each retry.
+        args: Arguments to be passed to the `callback` callable.
+        retries: The number of retries that have been performed.
+        max_retries: The maximum number of retries to perform.
+        retry_timeout: The time to sleep for each past retry.
+        callback: A callable to be called on each retry.
     """
-    def __init__(self, args, max_retries, retry_timeout, callback):
+
+    def __init__(
+        self,
+        args: Any,
+        max_retries: int,
+        retry_timeout: int,
+        callback: Callable[['Sleeper', int, Optional[Any]], Any]
+    ) -> None:
         self.args = args
         self.retries = 0
         self.max_retries = max_retries
         self.retry_timeout = retry_timeout
         self.callback = callback
 
-    def sleep(self, min_time=0):
+    def sleep(self, min_time: int = 0) -> None:
         """
         Sleeps for a minimum of `min_time` seconds. The actual sleeping time will increase
         with the number of retries.

--- a/mwclient/types.py
+++ b/mwclient/types.py
@@ -1,4 +1,7 @@
-from typing import Union, Tuple
+from http.cookiejar import CookieJar
+from typing import Union, Tuple, Mapping
+
+Cookies = Union[Mapping[str, str], CookieJar]
 
 Namespace = Union[str, int]
 

--- a/mwclient/types.py
+++ b/mwclient/types.py
@@ -1,0 +1,3 @@
+from typing import Union
+
+Namespace = Union[str, int]

--- a/mwclient/types.py
+++ b/mwclient/types.py
@@ -1,3 +1,5 @@
-from typing import Union
+from typing import Union, Tuple
 
 Namespace = Union[str, int]
+
+VersionTuple = Tuple[Union[int, str], ...]

--- a/mwclient/util.py
+++ b/mwclient/util.py
@@ -1,13 +1,14 @@
 import time
 import io
+from typing import Optional, Iterable, Tuple
 import warnings
 
 
-def parse_timestamp(t):
+def parse_timestamp(t: Optional[str]) -> time.struct_time:
     """Parses a string containing a timestamp.
 
     Args:
-        t (str): A string containing a timestamp.
+        t: A string containing a timestamp.
 
     Returns:
         time.struct_time: A timestamp.
@@ -17,7 +18,7 @@ def parse_timestamp(t):
     return time.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
 
 
-def read_in_chunks(stream, chunk_size):
+def read_in_chunks(stream: io.BufferedReader, chunk_size: int) -> Iterable[io.BytesIO]:
     while True:
         data = stream.read(chunk_size)
         if not data:
@@ -25,7 +26,9 @@ def read_in_chunks(stream, chunk_size):
         yield io.BytesIO(data)
 
 
-def handle_limit(limit, max_items, api_chunk_size):
+def handle_limit(
+    limit: Optional[int], max_items: Optional[int], api_chunk_size: Optional[int]
+) -> Tuple[Optional[int], Optional[int]]:
     """
     Consistently handles 'limit', 'api_chunk_size' and 'max_items' -
     https://github.com/mwclient/mwclient/issues/259 . In version 0.11,

--- a/mwclient/util.py
+++ b/mwclient/util.py
@@ -1,6 +1,6 @@
 import time
 import io
-from typing import Optional, Iterable, Tuple
+from typing import Optional, Iterable, Tuple, BinaryIO
 import warnings
 
 
@@ -18,7 +18,7 @@ def parse_timestamp(t: Optional[str]) -> time.struct_time:
     return time.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
 
 
-def read_in_chunks(stream: io.BufferedReader, chunk_size: int) -> Iterable[io.BytesIO]:
+def read_in_chunks(stream: BinaryIO, chunk_size: int) -> Iterable[io.BytesIO]:
     while True:
         data = stream.read(chunk_size)
         if not data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,17 @@ replace = "__version__ = '{new_version}'"
 
 [[tool.bumpversion.files]]
 filename = "README.md"
+
+[tool.mypy]
+packages = ["mwclient", "test"]
+strict = true
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = "test.*"
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "requests_oauthlib"
+ignore_missing_imports = true

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -155,8 +155,8 @@ class TestClient(TestCase):
         site = mwclient.Site('test.wikipedia.org')
 
         assert len(responses.calls) == 2
-        assert 'retry-after' in responses.calls[0].response.headers
-        assert 'retry-after' not in responses.calls[1].response.headers
+        assert 'retry-after' in responses.calls[0].response.headers  # type: ignore
+        assert 'retry-after' not in responses.calls[1].response.headers  # type: ignore
 
     @responses.activate
     def test_http_error(self):
@@ -204,6 +204,7 @@ class TestClient(TestCase):
 
         site = mwclient.Site('test.wikipedia.org')
 
+        assert responses.calls[0].request.url is not None
         assert 'action=query' in responses.calls[0].request.url
         assert 'meta=siteinfo%7Cuserinfo' in responses.calls[0].request.url
 
@@ -231,7 +232,8 @@ class TestClient(TestCase):
         self.httpShouldReturn(self.metaResponseAsJson())
 
         with pytest.raises(RuntimeError):
-            site = mwclient.Site('test.wikipedia.org', httpauth=1)
+            site = mwclient.Site('test.wikipedia.org',
+                                 httpauth=1)  # type: ignore[arg-type]
 
     @responses.activate
     def test_oauth(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -3,7 +3,7 @@ import logging
 import time
 import unittest
 import unittest.mock as mock
-from io import StringIO
+from io import BytesIO
 
 import pkg_resources  # part of setuptools
 import pytest
@@ -824,7 +824,7 @@ class TestClientUploadArgs(TestCase):
         # Test that methods are called, and arguments sent as expected
         self.configure()
 
-        self.site.upload(file=StringIO('test'), filename=self.vars['fname'], comment=self.vars['comment'])
+        self.site.upload(file=BytesIO(b'test'), filename=self.vars['fname'], comment=self.vars['comment'])
 
         args, kwargs = self.raw_call.call_args
         data = args[1]
@@ -840,19 +840,19 @@ class TestClientUploadArgs(TestCase):
         self.configure()
 
         with pytest.raises(TypeError):
-            self.site.upload(file=StringIO('test'))
+            self.site.upload(file=BytesIO(b'test'))
 
     def test_upload_ambigitious_args(self):
         self.configure()
 
         with pytest.raises(TypeError):
-            self.site.upload(filename='Test', file=StringIO('test'), filekey='abc')
+            self.site.upload(filename='Test', file=BytesIO(b'test'), filekey='abc')
 
     def test_upload_missing_upload_permission(self):
         self.configure(rights=['read'])
 
         with pytest.raises(mwclient.errors.InsufficientPermission):
-            self.site.upload(filename='Test', file=StringIO('test'))
+            self.site.upload(filename='Test', file=BytesIO(b'test'))
 
     def test_upload_file_exists(self):
         self.configure()
@@ -879,7 +879,7 @@ class TestClientUploadArgs(TestCase):
         ]
 
         with pytest.raises(mwclient.errors.FileExists):
-            self.site.upload(file=StringIO('test'), filename='Test.jpg', ignore=False)
+            self.site.upload(file=BytesIO(b'test'), filename='Test.jpg', ignore=False)
 
 
 class TestClientGetTokens(TestCase):

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -391,7 +391,7 @@ class TestList(unittest.TestCase):
         assert mock_site.get.call_args[0] == ("query",)
         assert mock_site.get.call_args[1]["titles"] == "Impossible"
         # covers the catch of AttributeError in get()
-        pg = pl[8052484]
+        pg = pl[8052484]  # type: ignore[index]
         assert isinstance(pg, Page)
         assert mock_site.get.call_args[0] == ("query",)
         assert mock_site.get.call_args[1]["pageids"] == 8052484

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -1,17 +1,10 @@
 import unittest
-import pytest
-import logging
-import requests
-import responses
-import json
-import mwclient
-from mwclient.page import Page
-from mwclient.client import Site
-from mwclient.listing import Category
-from mwclient.errors import APIError, AssertUserFailedError, ProtectedPageError, InvalidPageTitle
-
 import unittest.mock as mock
-
+import pytest
+import mwclient
+from mwclient.errors import APIError, AssertUserFailedError, ProtectedPageError, \
+    InvalidPageTitle
+from mwclient.page import Page
 
 if __name__ == "__main__":
     print()
@@ -270,7 +263,7 @@ class TestPageApiArgs(unittest.TestCase):
 
     def test_get_page_text_cached(self):
         # Check page.text() caching
-        self.page.revisions = mock.Mock(return_value=iter([]))
+        self.page.revisions = mock.Mock(return_value=iter([]))  # type: ignore
         self.page.text()
         self.page.text()
         # When cache is hit, revisions is not, so call_count should be 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,py313,flake
+envlist = py36,py37,py38,py39,py310,py311,py312,py313,flake,mypy
 
 [gh-actions]
 python =
@@ -9,7 +9,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    3.12: py312, flake, integration
+    3.12: py312, flake, integration, mypy
     3.13: py313
 
 [testenv]
@@ -26,3 +26,13 @@ commands =
 deps =
     pytest
 commands = py.test test/integration.py -v
+
+[testenv:mypy]
+deps =
+    mypy
+    pytest
+    responses
+    types-requests
+    types-setuptools
+commands =
+    mypy


### PR DESCRIPTION
Since dropping Python 2 support in #310, we now have the ability to add type annotations to the codebase. I think this could be very helpful for users to discover the API and to prevent bugs.

This PR is intended as a starting point for discussions (@mwclient/maintainers) and adds basic type annotations to all functions. Since we often return responses from the MediaWiki API verbatim, I've chosen to leave the return type as `Any` or `Dict[str, Any]` in many cases. This could be improved, for example, with `TypedDict`s, but I'm not sure we want to take on that maintenance burden.

Here are some open questions I have regarding this:
1. Do we want to maintain types in the first place?
2. Which type-checker should we use? I've chosen mypy for now, but we could, for example, use pyright instead.
3. Do we want to type responses, for example, using `TypedDict`?