### PR TITLE
Made 429 Too Many Request HTTP error in `raw_call()` of `client.py` retryable

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -494,7 +494,10 @@ class Site:
                     # fall through to the sleep
                 elif stream.status_code == 200:
                     return stream.text
-                elif (stream.status_code < 500 or stream.status_code > 599) and not stream.status_code == 429:  # 429 is Too Many Request - this is retryable:
+                elif (
+                    (stream.status_code < 500 or stream.status_code > 599)
+                    and stream.status_code != 429  # 429 Too Many Requests is retryable
+                ):
                     stream.raise_for_status()
                 else:
                     if not retry_on_error:

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -494,7 +494,7 @@ class Site:
                     # fall through to the sleep
                 elif stream.status_code == 200:
                     return stream.text
-                elif stream.status_code < 500 or stream.status_code > 599:
+                elif (stream.status_code < 500 or stream.status_code > 599) and not stream.status_code == 429:  # 429 is Too Many Request - this is retryable:
                     stream.raise_for_status()
                 else:
                     if not retry_on_error:


### PR DESCRIPTION
This prevents the program from straight-up failing, instead resorting to retries if they are enabled.