### PR TITLE
Deprecate `limit` for `api_chunk_size`, extend `max_items` (#259)

### DIFF
--- a/docs/source/user/implementation-notes.rst
+++ b/docs/source/user/implementation-notes.rst
@@ -13,7 +13,7 @@ Some notable exceptions:
 * ``usercontribs`` is ``usercontributions``
 * First parameters of ``search`` and ``usercontributions`` are ``search`` and ``user``, respectively
 
-Properties and generators are implemented as Python generators. Their limit parameter is only an indication of the number of items in one chunk. It is not the total limit. Doing ``list(generator(limit = limit))`` will return ALL items of generator, and not be limited by the limit value. Use ``list(generator(max_items = max_items))`` to limit the amount of items returned. Default chunk size is generally the maximum chunk size.
+Properties and generators are implemented as Python generators which yield one item per iteration. Their deprecated ``limit`` parameter is only an indication of the number of items retrieved from the API per request. It is not the total limit. Doing ``list(generator(limit = 50))`` will return ALL items, not 50, but it will query the API in chunks of 50 items at a time (so after yielding one item from the generator, the next 49 will be "free", then the next will trigger a new API call). The replacement ``api_chunk_size`` parameter does the same thing, but is more clearly named. If both ``limit`` and ``api_chunk_size`` are specified, ``limit`` will be ignored. The ``max_items`` parameter sets a total limit on the number of items which will be yielded. Use ``list(generator(max_items = 50))`` to limit the amount of items returned to 50. Higher level functions that have a ``limit`` parameter also now have ``api_chunk_size`` and ``max_items`` parameters that should be preferred. Default API chunk size is generally the maximum chunk size (500 for most wikis).
 
 Page objects
 ------------

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -11,7 +11,7 @@ from requests_oauthlib import OAuth1
 import mwclient.errors as errors
 import mwclient.listing as listing
 from mwclient.sleep import Sleepers
-from mwclient.util import parse_timestamp, read_in_chunks
+from mwclient.util import parse_timestamp, read_in_chunks, handle_limit
 
 __version__ = '0.10.1'
 
@@ -1140,9 +1140,10 @@ class Site:
     def allpages(self, start=None, prefix=None, namespace='0', filterredir='all',
                  minsize=None, maxsize=None, prtype=None, prlevel=None,
                  limit=None, dir='ascending', filterlanglinks='all', generator=True,
-                 end=None):
+                 end=None, max_items=None, api_chunk_size=None):
         """Retrieve all pages on the wiki as a generator."""
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('ap', generator)
         kwargs = dict(listing.List.generate_kwargs(
             pfx, ('from', start), ('to', end), prefix=prefix,
@@ -1151,60 +1152,76 @@ class Site:
             filterlanglinks=filterlanglinks,
         ))
         return listing.List.get_list(generator)(self, 'allpages', 'ap',
-                                                limit=limit, return_values='title',
+                                                max_items=max_items,
+                                                api_chunk_size=api_chunk_size,
+                                                return_values='title',
                                                 **kwargs)
 
     def allimages(self, start=None, prefix=None, minsize=None, maxsize=None, limit=None,
-                  dir='ascending', sha1=None, sha1base36=None, generator=True, end=None):
+                  dir='ascending', sha1=None, sha1base36=None, generator=True, end=None,
+                  max_items=None, api_chunk_size=None):
         """Retrieve all images on the wiki as a generator."""
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('ai', generator)
         kwargs = dict(listing.List.generate_kwargs(
             pfx, ('from', start), ('to', end), prefix=prefix,
             minsize=minsize, maxsize=maxsize,
             dir=dir, sha1=sha1, sha1base36=sha1base36,
         ))
-        return listing.List.get_list(generator)(self, 'allimages', 'ai', limit=limit,
+        return listing.List.get_list(generator)(self, 'allimages', 'ai',
+                                                max_items=max_items,
+                                                api_chunk_size=api_chunk_size,
                                                 return_values='timestamp|url',
                                                 **kwargs)
 
     def alllinks(self, start=None, prefix=None, unique=False, prop='title',
-                 namespace='0', limit=None, generator=True, end=None):
+                 namespace='0', limit=None, generator=True, end=None, max_items=None,
+                 api_chunk_size=None):
         """Retrieve a list of all links on the wiki as a generator."""
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('al', generator)
         kwargs = dict(listing.List.generate_kwargs(pfx, ('from', start), ('to', end),
                                                    prefix=prefix,
                                                    prop=prop, namespace=namespace))
         if unique:
             kwargs[pfx + 'unique'] = '1'
-        return listing.List.get_list(generator)(self, 'alllinks', 'al', limit=limit,
+        return listing.List.get_list(generator)(self, 'alllinks', 'al',
+                                                max_items=max_items,
+                                                api_chunk_size=api_chunk_size,
                                                 return_values='title', **kwargs)
 
     def allcategories(self, start=None, prefix=None, dir='ascending', limit=None,
-                      generator=True, end=None):
+                      generator=True, end=None, max_items=None, api_chunk_size=None):
         """Retrieve all categories on the wiki as a generator."""
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         pfx = listing.List.get_prefix('ac', generator)
         kwargs = dict(listing.List.generate_kwargs(pfx, ('from', start), ('to', end),
                                                    prefix=prefix, dir=dir))
-        return listing.List.get_list(generator)(self, 'allcategories', 'ac', limit=limit,
-                                                **kwargs)
+        return listing.List.get_list(generator)(self, 'allcategories', 'ac',
+                                                max_items=max_items,
+                                                api_chunk_size=api_chunk_size, **kwargs)
 
     def allusers(self, start=None, prefix=None, group=None, prop=None, limit=None,
-                 witheditsonly=False, activeusers=False, rights=None, end=None):
+                 witheditsonly=False, activeusers=False, rights=None, end=None,
+                 max_items=None, api_chunk_size=None):
         """Retrieve all users on the wiki as a generator."""
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('au', ('from', start), ('to', end),
                                                    prefix=prefix,
                                                    group=group, prop=prop,
                                                    rights=rights,
                                                    witheditsonly=witheditsonly,
                                                    activeusers=activeusers))
-        return listing.List(self, 'allusers', 'au', limit=limit, **kwargs)
+        return listing.List(self, 'allusers', 'au', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def blocks(self, start=None, end=None, dir='older', ids=None, users=None, limit=None,
-               prop='id|user|by|timestamp|expiry|reason|flags'):
+               prop='id|user|by|timestamp|expiry|reason|flags', max_items=None,
+               api_chunk_size=None):
         """Retrieve blocks as a generator.
 
         API doc: https://www.mediawiki.org/wiki/API:Blocks
@@ -1230,19 +1247,24 @@ class Site:
         """
 
         # TODO: Fix. Fix what?
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('bk', start=start, end=end, dir=dir,
                                                    ids=ids, users=users, prop=prop))
-        return listing.List(self, 'blocks', 'bk', limit=limit, **kwargs)
+        return listing.List(self, 'blocks', 'bk', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def deletedrevisions(self, start=None, end=None, dir='older', namespace=None,
-                         limit=None, prop='user|comment'):
+                         limit=None, prop='user|comment', max_items=None,
+                         api_chunk_size=None):
         # TODO: Fix
-
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('dr', start=start, end=end, dir=dir,
                                                    namespace=namespace, prop=prop))
-        return listing.List(self, 'deletedrevs', 'dr', limit=limit, **kwargs)
+        return listing.List(self, 'deletedrevs', 'dr', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
-    def exturlusage(self, query, prop=None, protocol='http', namespace=None, limit=None):
+    def exturlusage(self, query, prop=None, protocol='http', namespace=None, limit=None,
+                    max_items=None, api_chunk_size=None):
         r"""Retrieve the list of pages that link to a particular domain or URL,
          as a generator.
 
@@ -1264,51 +1286,64 @@ class Site:
 
         """
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('eu', query=query, prop=prop,
                                                    protocol=protocol,
                                                    namespace=namespace))
-        return listing.List(self, 'exturlusage', 'eu', limit=limit, **kwargs)
+        return listing.List(self, 'exturlusage', 'eu', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def logevents(self, type=None, prop=None, start=None, end=None,
-                  dir='older', user=None, title=None, limit=None, action=None):
+                  dir='older', user=None, title=None, limit=None, action=None,
+                  max_items=None, api_chunk_size=None):
         """Retrieve logevents as a generator."""
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('le', prop=prop, type=type,
                                                    start=start, end=end, dir=dir,
                                                    user=user, title=title, action=action))
-        return listing.List(self, 'logevents', 'le', limit=limit, **kwargs)
+        return listing.List(self, 'logevents', 'le', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
-    def checkuserlog(self, user=None, target=None, limit=10, dir='older',
-                     start=None, end=None):
+    def checkuserlog(self, user=None, target=None, limit=None, dir='older',
+                     start=None, end=None, max_items=None, api_chunk_size=10):
         """Retrieve checkuserlog items as a generator."""
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('cul', target=target, start=start,
                                                    end=end, dir=dir, user=user))
         return listing.NestedList('entries', self, 'checkuserlog', 'cul',
-                                  limit=limit, **kwargs)
+                                  max_items=max_items, api_chunk_size=api_chunk_size,
+                                  **kwargs)
 
     # def protectedtitles requires 1.15
-    def random(self, namespace, limit=20):
+    def random(self, namespace, limit=None, max_items=None, api_chunk_size=20):
         """Retrieve a generator of random pages from a particular namespace.
 
-        limit specifies the number of random articles retrieved.
+        max_items specifies the number of random articles retrieved.
+        api_chunk_size and limit (deprecated) specify the API chunk size.
         namespace is a namespace identifier integer.
 
         Generator contains dictionary with namespace, page ID and title.
 
         """
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('rn', namespace=namespace))
-        return listing.List(self, 'random', 'rn', limit=limit, **kwargs)
+        return listing.List(self, 'random', 'rn', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def recentchanges(self, start=None, end=None, dir='older', namespace=None,
-                      prop=None, show=None, limit=None, type=None, toponly=None):
+                      prop=None, show=None, limit=None, type=None, toponly=None,
+                      max_items=None, api_chunk_size=None):
         """List recent changes to the wiki, à la Special:Recentchanges.
         """
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('rc', start=start, end=end, dir=dir,
                                                    namespace=namespace, prop=prop,
                                                    show=show, type=type,
                                                    toponly='1' if toponly else None))
-        return listing.List(self, 'recentchanges', 'rc', limit=limit, **kwargs)
+        return listing.List(self, 'recentchanges', 'rc', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def revisions(self, revids, prop='ids|timestamp|flags|comment|user'):
         """Get data about a list of revisions.
@@ -1345,7 +1380,8 @@ class Site:
                 revisions.append(revision)
         return revisions
 
-    def search(self, search, namespace='0', what=None, redirects=False, limit=None):
+    def search(self, search, namespace='0', what=None, redirects=False, limit=None,
+               max_items=None, api_chunk_size=None):
         """Perform a full text search.
 
         API doc: https://www.mediawiki.org/wiki/API:Search
@@ -1370,24 +1406,28 @@ class Site:
         Returns:
             mwclient.listings.List: Search results iterator
         """
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('sr', search=search,
                                                    namespace=namespace, what=what))
         if redirects:
             kwargs['srredirects'] = '1'
-        return listing.List(self, 'search', 'sr', limit=limit, **kwargs)
+        return listing.List(self, 'search', 'sr', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def usercontributions(self, user, start=None, end=None, dir='older', namespace=None,
-                          prop=None, show=None, limit=None, uselang=None):
+                          prop=None, show=None, limit=None, uselang=None, max_items=None,
+                          api_chunk_size=None):
         """
         List the contributions made by a given user to the wiki.
 
         API doc: https://www.mediawiki.org/wiki/API:Usercontribs
         """
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('uc', user=user, start=start, end=end,
                                                    dir=dir, namespace=namespace,
                                                    prop=prop, show=show))
-        return listing.List(self, 'usercontribs', 'uc', limit=limit, uselang=uselang,
-                            **kwargs)
+        return listing.List(self, 'usercontribs', 'uc', max_items=max_items,
+                            api_chunk_size=api_chunk_size, uselang=uselang, **kwargs)
 
     def users(self, users, prop='blockinfo|groups|editcount'):
         """
@@ -1399,19 +1439,21 @@ class Site:
         return listing.List(self, 'users', 'us', ususers='|'.join(users), usprop=prop)
 
     def watchlist(self, allrev=False, start=None, end=None, namespace=None, dir='older',
-                  prop=None, show=None, limit=None):
+                  prop=None, show=None, limit=None, max_items=None, api_chunk_size=None):
         """
         List the pages on the current user's watchlist.
 
         API doc: https://www.mediawiki.org/wiki/API:Watchlist
         """
 
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         kwargs = dict(listing.List.generate_kwargs('wl', start=start, end=end,
                                                    namespace=namespace, dir=dir,
                                                    prop=prop, show=show))
         if allrev:
             kwargs['wlallrev'] = '1'
-        return listing.List(self, 'watchlist', 'wl', limit=limit, **kwargs)
+        return listing.List(self, 'watchlist', 'wl', max_items=max_items,
+                            api_chunk_size=api_chunk_size, **kwargs)
 
     def expandtemplates(self, text, title=None, generatexml=False):
         """

--- a/mwclient/image.py
+++ b/mwclient/image.py
@@ -1,3 +1,4 @@
+from mwclient.util import handle_limit
 import mwclient.listing
 import mwclient.page
 
@@ -28,7 +29,7 @@ class Image(mwclient.page.Page):
         )
 
     def imageusage(self, namespace=None, filterredir='all', redirect=False,
-                   limit=None, generator=True):
+                   limit=None, generator=True, max_items=None, api_chunk_size=None):
         """
         List pages that use the given file.
 
@@ -38,19 +39,36 @@ class Image(mwclient.page.Page):
         kwargs = dict(mwclient.listing.List.generate_kwargs(
             prefix, title=self.name, namespace=namespace, filterredir=filterredir
         ))
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
         if redirect:
             kwargs['%sredirect' % prefix] = '1'
         return mwclient.listing.List.get_list(generator)(
-            self.site, 'imageusage', 'iu', limit=limit, return_values='title', **kwargs
+            self.site,
+            'imageusage',
+            'iu',
+            max_items=max_items,
+            api_chunk_size=api_chunk_size,
+            return_values='title',
+            **kwargs
         )
 
-    def duplicatefiles(self, limit=None):
+    def duplicatefiles(self, limit=None, max_items=None, api_chunk_size=None):
         """
         List duplicates of the current file.
 
         API doc: https://www.mediawiki.org/wiki/API:Duplicatefiles
+
+        limit sets a hard cap on the total number of results, it does
+        not only specify the API chunk size.
         """
-        return mwclient.listing.PageProperty(self, 'duplicatefiles', 'df', dflimit=limit)
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
+        return mwclient.listing.PageProperty(
+            self,
+            'duplicatefiles',
+            'df',
+            max_items=max_items,
+            api_chunk_size=api_chunk_size
+        )
 
     def download(self, destination=None):
         """

--- a/mwclient/util.py
+++ b/mwclient/util.py
@@ -1,5 +1,6 @@
 import time
 import io
+import warnings
 
 
 def parse_timestamp(t):
@@ -22,3 +23,30 @@ def read_in_chunks(stream, chunk_size):
         if not data:
             break
         yield io.BytesIO(data)
+
+
+def handle_limit(limit, max_items, api_chunk_size):
+    """
+    Consistently handles 'limit', 'api_chunk_size' and 'max_items' -
+    https://github.com/mwclient/mwclient/issues/259 . In version 0.11,
+    'api_chunk_size' was introduced as a better name for 'limit', but
+    we still accept 'limit' with a deprecation warning. 'max_items'
+    does what 'limit' sounds like it should.
+    """
+    if limit:
+        if api_chunk_size:
+            warnings.warn(
+                "limit and api_chunk_size both specified, this is not supported! limit "
+                "is deprecated, will use value of api_chunk_size",
+                DeprecationWarning
+            )
+        else:
+            warnings.warn(
+                "limit is deprecated as its name and purpose are confusing. use "
+                "api_chunk_size to set the number of items retrieved from the API at "
+                "once, and/or max_items to limit the total number of items that will be "
+                "yielded",
+                DeprecationWarning
+            )
+            api_chunk_size = limit
+    return (max_items, api_chunk_size)

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -22,7 +22,54 @@ class TestList(unittest.TestCase):
     def setUp(self):
         pass
 
-    def setupDummyResponses(self, mock_site, result_member, ns=None):
+    def setupDummyResponsesOne(self, mock_site, result_member, ns=None):
+        if ns is None:
+            ns = [0, 0, 0]
+        mock_site.get.side_effect = [
+            {
+                'continue': {
+                    'apcontinue': 'Kre_Mbaye',
+                    'continue': '-||'
+                },
+                'query': {
+                    result_member: [
+                        {
+                            "pageid": 19839654,
+                            "ns": ns[0],
+                            "title": "Kre'fey",
+                        },
+                    ]
+                }
+            },
+            {
+                'continue': {
+                    'apcontinue': 'Kre_Blip',
+                    'continue': '-||'
+                },
+                'query': {
+                    result_member: [
+                        {
+                            "pageid": 19839654,
+                            "ns": ns[1],
+                            "title": "Kre-O",
+                        }
+                    ]
+                }
+            },
+            {
+                'query': {
+                    result_member: [
+                        {
+                            "pageid": 30955295,
+                            "ns": ns[2],
+                            "title": "Kre-O Transformers",
+                        }
+                    ]
+                }
+            },
+        ]
+
+    def setupDummyResponsesTwo(self, mock_site, result_member, ns=None):
         if ns is None:
             ns = [0, 0, 0]
         mock_site.get.side_effect = [
@@ -64,19 +111,65 @@ class TestList(unittest.TestCase):
         # Test that the list fetches all three responses
         # and yields dicts when return_values not set
 
-        lst = List(mock_site, 'allpages', 'ap', limit=2)
-        self.setupDummyResponses(mock_site, 'allpages')
+        lst = List(mock_site, 'allpages', 'ap', api_chunk_size=2)
+        self.setupDummyResponsesTwo(mock_site, 'allpages')
         vals = [x for x in lst]
 
         assert len(vals) == 3
         assert type(vals[0]) == dict
+        assert lst.args["aplimit"] == "2"
+        assert mock_site.get.call_count == 2
+
+    @mock.patch('mwclient.client.Site')
+    def test_list_limit_deprecated(self, mock_site):
+        # Test that the limit arg acts as api_chunk_size but generates
+        # DeprecationWarning
+
+        with pytest.deprecated_call():
+            lst = List(mock_site, 'allpages', 'ap', limit=2)
+        self.setupDummyResponsesTwo(mock_site, 'allpages')
+        vals = [x for x in lst]
+
+        assert len(vals) == 3
+        assert type(vals[0]) == dict
+        assert lst.args["aplimit"] == "2"
+        assert mock_site.get.call_count == 2
+
+    @mock.patch('mwclient.client.Site')
+    def test_list_max_items(self, mock_site):
+        # Test that max_items properly caps the list
+        # iterations
+
+        mock_site.api_limit = 500
+        lst = List(mock_site, 'allpages', 'ap', max_items=2)
+        self.setupDummyResponsesTwo(mock_site, 'allpages')
+        vals = [x for x in lst]
+
+        assert len(vals) == 2
+        assert type(vals[0]) == dict
+        assert lst.args["aplimit"] == "2"
+        assert mock_site.get.call_count == 1
+
+    @mock.patch('mwclient.client.Site')
+    def test_list_max_items_continuation(self, mock_site):
+        # Test that max_items and api_chunk_size work together
+
+        mock_site.api_limit = 500
+        lst = List(mock_site, 'allpages', 'ap', max_items=2, api_chunk_size=1)
+        self.setupDummyResponsesOne(mock_site, 'allpages')
+        vals = [x for x in lst]
+
+        assert len(vals) == 2
+        assert type(vals[0]) == dict
+        assert lst.args["aplimit"] == "1"
+        assert mock_site.get.call_count == 2
 
     @mock.patch('mwclient.client.Site')
     def test_list_with_str_return_value(self, mock_site):
         # Test that the List yields strings when return_values is string
 
         lst = List(mock_site, 'allpages', 'ap', limit=2, return_values='title')
-        self.setupDummyResponses(mock_site, 'allpages')
+        self.setupDummyResponsesTwo(mock_site, 'allpages')
         vals = [x for x in lst]
 
         assert len(vals) == 3
@@ -88,7 +181,7 @@ class TestList(unittest.TestCase):
 
         lst = List(mock_site, 'allpages', 'ap', limit=2,
                    return_values=('title', 'ns'))
-        self.setupDummyResponses(mock_site, 'allpages')
+        self.setupDummyResponsesTwo(mock_site, 'allpages')
         vals = [x for x in lst]
 
         assert len(vals) == 3
@@ -98,8 +191,9 @@ class TestList(unittest.TestCase):
     def test_generator_list(self, mock_site):
         # Test that the GeneratorList yields Page objects
 
+        mock_site.api_limit = 500
         lst = GeneratorList(mock_site, 'pages', 'p')
-        self.setupDummyResponses(mock_site, 'pages', ns=[0, 6, 14])
+        self.setupDummyResponsesTwo(mock_site, 'pages', ns=[0, 6, 14])
         vals = [x for x in lst]
 
         assert len(vals) == 3


### PR DESCRIPTION
As discussed in #259, the `limit` parameter - to the low-level `listing.List` and its subclasses, and to various higher-level functions which ultimately return `List` or `GeneratorList` instances - is confusing and misleading.

It is passed through to the API calls, and effectively specifies how many items a single API call will return. But because our `List` yields a single item at a time and will keep doing API calls until the API says there's no more data, it does not limit how many items our `List` will yield, nor specify its chunk size. It seems natural to expect that `List(limit=10)` or `page.revisions(limit=10)` will give you a generator that yields only 10 items, or yields 10 items at a time, but it does not; it gives you a generator which queries the API in chunks of 10 items at a time, but will yield every item the API gives it, one by one.

This is probably not ever how we really intended mwclient to work (there's an old `# NOTE: Fix limit` comment which implies as much) but it has worked this way for 16 years, so we should probably not change it just in case someone really has a need to specify the API chunk size for some reason, or some code somehow happens to implicitly rely on it behaving the way it does.

So, this keeps the behaviour of the `limit` param wherever it exists, but triggers a deprecation warning. Everything that had a `limit` param now also has an `api_chunk_size` param that does the same thing, but is more explicitly named and does not trigger a deprecation warning. And everything that had a `limit` param now also has a `max_items` param that does what it sounds like, and what people are more likely to want - sets an absolute limit on the number of items the generator will yield.

For efficiency, if `max_items` is set, neither `limit` nor `api_chunk_size` is set, and `max_items` is below
`site.api_limit`, we set the API chunk size to `max_items` so we only retrieve as many items as we actually need.