### PR TITLE
0.11.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For functions not available in the current MediaWiki,
 a `MediaWikiVersionError` is raised.
 
 The current stable
-[version 0.10.1](https://github.com/mwclient/mwclient/archive/v0.10.1.zip)
+[version 0.11.0](https://github.com/mwclient/mwclient/archive/v0.11.0.zip)
 is [available through PyPI](https://pypi.python.org/pypi/mwclient):
 
 ```

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -13,7 +13,7 @@ import mwclient.listing as listing
 from mwclient.sleep import Sleepers
 from mwclient.util import parse_timestamp, read_in_chunks, handle_limit
 
-__version__ = '0.10.1'
+__version__ = '0.11.0'
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 addopts = "--cov mwclient test"
 
 [tool.bumpversion]
-current_version = "0.10.1"
+current_version = "0.11.0"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ replace = "version='{new_version}'"
 
 [[tool.bumpversion.files]]
 filename = "mwclient/client.py"
+search = "__version__ = '{current_version}'"
+replace = "__version__ = '{new_version}'"
 
 [[tool.bumpversion.files]]
 filename = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ pytest_runner = ['pytest-runner'] if needs_pytest else []
 setup(name='mwclient',
       # See https://mwclient.readthedocs.io/en/latest/development/#making-a-release
       # for how to update this field and release a new version.
-      version='0.10.1',
+      version='0.11.0',
       description='MediaWiki API client',
       long_description=README,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This has the commit for the 0.11.0 release, plus a preparatory tweak to pyproduct.md. After merging this I need to figure out how to get the tag pushed, then the release should happen.