### PR TITLE
Fix/initialize size after clientlogin

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -814,6 +814,7 @@ class Site:
                 login = self.post('clientlogin', **kwargs)
                 status = login['clientlogin'].get('status')
                 if status == 'PASS':
+                    self.site_init()
                     return True
                 elif status in ('UI', 'REDIRECT'):
                     return login['clientlogin']


### PR DESCRIPTION
This fix (first commit) ensures that the `Site` object is properly initialized after a successful `Site.clientlogin`, matching the existing behavior of `Site.login()`.

Previously, developers needed to manually invoke `Site.site_init()` after using `clientlogin`, which could lead to unexpected issues, especially during migration from `login` to `clientlogin`.

For example, the following code works with `Site.login`:

```python
site = mwclient.Site('localhost:8080', path='/', scheme='http')
site.login('username', 'super-secret')
with open('/tmp/image.png', 'rb') as f:
    site.upload(f, 'image.png', 'Some test upload', ignore=True)
```

But when using `Site.clientlogin` without this fix, the code would fail with `mwclient.errors.InsufficientPermission: image.png`:

```python
site = mwclient.Site('localhost:8080', path='/', scheme='http')
site.clientlogin(username='username', password='super-secret')
with open('/tmp/image.png', 'rb') as f:
    site.upload(f, 'image.png', 'Some test upload', ignore=True)
```

The second commit refactors the method, removing some redundant logic.