### PR TITLE
Make logged_in more accurate

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -102,6 +102,7 @@ class Site:
         self.compress = compress
         self.max_lag = str(max_lag)
         self.force_login = force_login
+        self.logged_in = False
         if reqs and connection_options:
             raise ValueError(
                 "reqs is a deprecated alias of connection_options. Do not specify both."
@@ -381,13 +382,14 @@ class Site:
         try:
             userinfo = info['query']['userinfo']
         except KeyError:
-            userinfo = ()
+            userinfo = {}
         if 'blockedby' in userinfo:
             self.blocked = (userinfo['blockedby'], userinfo.get('blockreason', ''))
         else:
             self.blocked = False
         self.hasmsg = 'messages' in userinfo
-        self.logged_in = 'anon' not in userinfo
+        if userinfo:
+            self.logged_in = 'anon' not in userinfo
         if 'warnings' in info:
             for module, warning in info['warnings'].items():
                 if '*' in warning:


### PR DESCRIPTION
I found this while writing integration tests. If you try to login with an incorrect username and password, mwclient correctly raises mwclient.errors.LoginError...but if you then check logged_in, it is True. Clearly that's wrong.

The logic for setting logged_in will basically consider us logged in any time we process an API call and there is no 'anon' key in the userinfo dict *or there is no userinfo dict at all*. The last API call processed on a failed login attempt has no userinfo dict.

This tweaks it so we only changed the logged_in value (in either direction) if the API call we're handling has a userinfo dict.

We also fix the type of the empty userinfo we create if there isn't one in the call (no idea why it was a tuple, it doesn't really matter but it's weird) and explicitly set self.logged_in to False in Site initialization. I don't think this is strictly necessary as we can expect the init process to result in at least one API call with a userinfo dict, but it feels more correct.