### PR TITLE
Remove deprecated pytest-runner and setup.py test

### DIFF
--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -38,33 +38,31 @@ Create a new branch for your changes:
 Test suite
 ----------
 
-mwclient ships with a test suite based on `pytest <https://pytest.org>`_.
-While it's far from complete, it can sometimes alert you if you break things.
+mwclient ships with a test suite based on `pytest <https://pytest.org>`_. While
+it's far from complete, it can sometimes alert you if you break things.
 
-The easiest way to run the tests is:
-
-.. code:: bash
-
-    $ python setup.py test
-
-This will make an in-place build and download test dependencies locally if needed.
-Tests will run faster, however, if you do an
-`editable install <https://pip.readthedocs.org/en/latest/reference/pip_install.html#editable-installs>`_
-and run pytest directly:
-
-.. code:: bash
-
-    $ pip install pytest pytest-cov flake8 responses mock
-    $ pip install -e .
-    $ py.test
-
-If you want to test with different Python versions in isolated virtualenvs,
-you can use `Tox <https://tox.testrun.org/>`_. A `tox.ini` file is included.
+To run the test suite, you can use `tox <https://tox.testrun.org/>`_. Tox will
+create a virtual environment for each Python version you want to test with,
+install the dependencies, and run the tests.
 
 .. code:: bash
 
     $ pip install tox
     $ tox
+
+If you want to run the tests for a single Python version, you can do so by
+specifying the Python version, e.g. to run the tests for Python 3.9:
+
+.. code:: bash
+
+    $ tox -e py39
+
+Alternatively, you can run the tests directly with pytest:
+
+.. code:: bash
+
+    $ pip install -e '.[testing]'
+    $ py.test
 
 If you would like to expand the test suite by adding more tests, please go ahead!
 
@@ -80,7 +78,7 @@ To build the documentation locally for testing:
 
 .. code:: bash
 
-    $ pip install Sphinx sphinx-rtd-theme
+    $ pip install -r docs/requirements.txt
     $ cd docs
     $ make html
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 import os
-import sys
+
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.md')).read()
-
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
+with open(os.path.join(here, 'README.md'), "r", encoding="utf-8") as f:
+    README = f.read()
 
 setup(name='mwclient',
       # See https://mwclient.readthedocs.io/en/latest/development/#making-a-release
@@ -33,8 +31,9 @@ setup(name='mwclient',
       license='MIT',
       packages=['mwclient'],
       install_requires=['requests-oauthlib'],
-      setup_requires=pytest_runner,
-      tests_require=['pytest', 'pytest-cov',
-                     'responses>=0.3.0', 'responses!=0.6.0', 'setuptools'],
+      extras_require={
+          'testing': ['pytest', 'pytest-cov',
+                      'responses>=0.3.0', 'responses!=0.6.0', 'setuptools'],
+      },
       zip_safe=True
       )

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,7 @@ python =
     3.13: py313
 
 [testenv]
-deps =
-    pytest
-    pytest-cov
-    responses
-    setuptools
-    mock
+extras = testing
 commands = py.test -v --cov mwclient test
 
 [testenv:flake]


### PR DESCRIPTION
The `setup.py test` command and pytest-runner have been deprecated for several years and are no longer recommended. The pytest documentation no longer recommends pytest-runner and their own documentation recommends against it.

- https://github.com/pypa/setuptools/issues/1684
- https://github.com/pytest-dev/pytest/issues/5534
- https://github.com/pytest-dev/pytest-runner/issues/50

Changes made:

- Removed pytest-runner: Eliminated the use of pytest-runner from `setup.py`.
- Moved test dependencies to the `extra-dependencies`, which can be used by tox as well as for manual installation.
- Updated the documentation to recommend using tox as the default test runner. Alternatively, users can manually run tests with the `py.test` command.

These changes will also make an eventual migration to `pyproject.toml` easier, as the `extras_require` can be copied to the `project.optional-dependencies` section.