### PR TITLE
100% test coverage for listing.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mwclient is a lightweight Python client library to the
 [MediaWiki API](https://mediawiki.org/wiki/API)
 which provides access to most API functionality.
 It works with Python 3.6 and above,
-and supports MediaWiki 1.16 and above.
+and supports MediaWiki 1.21 and above.
 For functions not available in the current MediaWiki,
 a `MediaWikiVersionError` is raised.
 

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -340,6 +340,8 @@ class Site:
         """
         kwargs.update(args)
 
+        # this enables new-style continuation in mediawiki 1.21
+        # through 1.25, can be dropped when we bump baseline to 1.26
         if action == 'query' and 'continue' not in kwargs:
             kwargs['continue'] = ''
         if action == 'query':

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -247,7 +247,7 @@ class PageList(GeneratorList):
             try:
                 namespace = self.guess_namespace(name)
             except AttributeError:
-                # raised when `namespace` doesn't have a `startswith` attribute
+                # raised when `name` doesn't have a `startswith` attribute
                 namespace = 0
 
         cls = {

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -275,10 +275,6 @@ class PageList(GeneratorList):
             namespace = f'{self.site.namespaces[ns].replace(" ", "_")}:'
             if name.startswith(namespace):
                 return ns
-            elif ns in self.site.default_namespaces:
-                namespace = f'{self.site.default_namespaces[ns].replace(" ", "_")}:'
-                if name.startswith(namespace):
-                    return ns
         return 0
 
 

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -88,11 +88,8 @@ class List:
         Else, update the iterator accordingly.
 
         If 'continue' is in the response, it is added to `self.args`
-        (new style continuation, added in MediaWiki 1.21).
-
-        If not, but 'query-continue' is in the response, query its
-        item called `self.list_name` and add this to `self.args` (old
-        style continuation).
+        (new style continuation, added in MediaWiki 1.21, default
+        since MediaWiki 1.26).
 
         Else, set `self.last` to True.
         """
@@ -112,10 +109,6 @@ class List:
         if data.get('continue'):
             # New style continuation, added in MediaWiki 1.21
             self.args.update(data['continue'])
-
-        elif self.list_name in data.get('query-continue', ()):
-            # Old style continuation
-            self.args.update(data['query-continue'][self.list_name])
 
         else:
             self.last = True

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -184,6 +184,18 @@ class TestList(unittest.TestCase):
         assert type(vals[0]) == tuple
 
     @mock.patch('mwclient.client.Site')
+    def test_list_empty(self, mock_site):
+        # Test that we handle an empty response from get correctly
+        # (stop iterating)
+
+        lst = List(mock_site, 'allpages', 'ap', limit=2,
+                   return_values=('title', 'ns'))
+        mock_site.get.side_effect = [{}]
+        vals = [x for x in lst]
+
+        assert len(vals) == 0
+
+    @mock.patch('mwclient.client.Site')
     def test_generator_list(self, mock_site):
         # Test that the GeneratorList yields Page objects
 

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -1,9 +1,5 @@
 import unittest
 import pytest
-import logging
-import requests
-import responses
-import json
 import mwclient
 from mwclient.listing import List, GeneratorList
 
@@ -200,6 +196,7 @@ class TestList(unittest.TestCase):
         assert type(vals[0]) == mwclient.page.Page
         assert type(vals[1]) == mwclient.image.Image
         assert type(vals[2]) == mwclient.listing.Category
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -192,7 +192,33 @@ class TestList(unittest.TestCase):
                    return_values=('title', 'ns'))
         mock_site.get.side_effect = [{}]
         vals = [x for x in lst]
+        assert len(vals) == 0
 
+    @mock.patch('mwclient.client.Site')
+    def test_list_invalid(self, mock_site):
+        # Test that we handle the response for a list that doesn't
+        # exist correctly (set an empty iterator, then stop
+        # iterating)
+
+        mock_site.api_limit = 500
+        lst = List(mock_site, 'allpagess', 'ap')
+        mock_site.get.side_effect = [
+            {
+                'batchcomplete': '',
+                'warnings': {
+                    'main': {'*': 'Unrecognized parameter: aplimit.'},
+                    'query': {'*': 'Unrecognized value for parameter "list": allpagess'}
+                },
+                'query': {
+                    'userinfo': {
+                        'id': 0,
+                        'name': 'DEAD:BEEF:CAFE',
+                        'anon': ''
+                    }
+                }
+            }
+        ]
+        vals = [x for x in lst]
         assert len(vals) == 0
 
     @mock.patch('mwclient.client.Site')

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -222,6 +222,15 @@ class TestList(unittest.TestCase):
         assert len(vals) == 0
 
     @mock.patch('mwclient.client.Site')
+    def test_list_repr(self, mock_site):
+        # Test __repr__ of a List is as expected
+
+        mock_site.__str__.return_value = "some wiki"
+        lst = List(mock_site, 'allpages', 'ap', limit=2,
+                   return_values=('title', 'ns'))
+        assert repr(lst) == "<List object 'allpages' for some wiki>"
+
+    @mock.patch('mwclient.client.Site')
     def test_generator_list(self, mock_site):
         # Test that the GeneratorList yields Page objects
 


### PR DESCRIPTION
These commits together get listing.py test coverage up to 100%. They include a couple of functional changes where I think it makes more sense to change the code than change the tests. Particularly notably, it would bump our baseline version of mediawiki to 1.26, which was released in 2015 and has been obsolete since 2016. We could do some follow-up commits to drop conditionals for older releases, if we agree this bump is reasonable.