### PR TITLE
Update version_tuple_from_generator to match PHPs' rules

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -864,7 +864,7 @@ class Site:
         Raises:
             errors.APIError: A token of the given type could not be retrieved.
         """
-        if self.version is None or self.version[:2] >= (1, 24):
+        if self.version is None or self.require(1, 24, raise_error=False):
             # The 'csrf' (cross-site request forgery) token introduced in 1.24 replaces
             # the majority of older tokens, like edittoken and movetoken.
             if type not in {'watch', 'patrol', 'rollback', 'userrights', 'login'}:
@@ -874,8 +874,7 @@ class Site:
             self.tokens[type] = '0'
 
         if self.tokens.get(type, '0') == '0' or force:
-
-            if self.version is None or self.version[:2] >= (1, 24):
+            if self.version is None or self.require(1, 24, raise_error=False):
                 # We use raw_api() rather than api() because api() is adding "userinfo"
                 # to the query and this raises a readapideniederror if the wiki is read
                 # protected, and we're trying to fetch a login token.
@@ -967,7 +966,7 @@ class Site:
             content_size = file.seek(0, 2)
             file.seek(0)
 
-            if self.version[:2] >= (1, 20) and content_size > self.chunk_size:
+            if self.require(1, 20, raise_error=False) and content_size > self.chunk_size:
                 return self.chunk_upload(file, filename, ignore, comment, text)
 
         predata = {
@@ -986,7 +985,7 @@ class Site:
 
         # sessionkey was renamed to filekey in MediaWiki 1.18
         # https://phabricator.wikimedia.org/rMW5f13517e36b45342f228f3de4298bb0fe186995d
-        if self.version[:2] < (1, 18):
+        if not self.require(1, 18, raise_error=False):
             predata['sessionkey'] = filekey
         else:
             predata['filekey'] = filekey

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -241,7 +241,7 @@ class Site:
             prefix (str): The expected prefix of the string.
 
         Returns:
-            A tuple containing the individual elements of the given version number.
+            tuple[int, int, Union[int, str]...]: The version tuple.
         """
         if not string.startswith(prefix):
             raise errors.MediaWikiVersionError(f'Unknown generator {string}')
@@ -279,6 +279,15 @@ class Site:
 
         if len(version_tuple) < 2:
             raise errors.MediaWikiVersionError(f'Unknown MediaWiki {".".join(version)}')
+
+        # Ensure the major and minor version components are integers.
+        # Non-integer values for these components are not supported and will
+        # cause comparison issues.
+        if not all(isinstance(segment, int) for segment in version_tuple[:2]):
+            raise errors.MediaWikiVersionError(
+                f'Unknown MediaWiki {".".join(version)}. '
+                'Major and minor version must be integers.'
+            )
 
         return version_tuple
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -756,6 +756,21 @@ class TestVersionTupleFromGenerator:
         with pytest.raises(mwclient.errors.MediaWikiVersionError):
             mwclient.Site.version_tuple_from_generator('MediaWiki 1')
 
+    def test_version_tuple_from_generator_major_is_not_number(self):
+        with pytest.raises(mwclient.errors.MediaWikiVersionError):
+            mwclient.Site.version_tuple_from_generator('MediaWiki foo.24.1')
+
+    def test_version_tuple_from_generator_minor_is_not_number(self):
+        with pytest.raises(mwclient.errors.MediaWikiVersionError):
+            mwclient.Site.version_tuple_from_generator('MediaWiki 1.foo.1')
+
+    def test_version_tuple_from_generator_major_and_minor_are_not_numbers(self):
+        with pytest.raises(mwclient.errors.MediaWikiVersionError):
+            mwclient.Site.version_tuple_from_generator('MediaWiki foo.bar.1')
+
+    def test_version_tuple_from_generator_patch_is_not_number(self):
+        assert mwclient.Site.version_tuple_from_generator('MediaWiki 1.24.foo') == (1, 24, 'foo')
+
 
 class TestClientUploadArgs(TestCase):
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -736,10 +736,10 @@ class TestVersionTupleFromGenerator:
     @pytest.mark.parametrize('version, expected', [
         ('MediaWiki 1.24', (1, 24)),
         ('MediaWiki 1.24.0', (1, 24, 0)),
-        ('MediaWiki 1.24.0-wmf.1', (1, 24, 0, '-wmf', 1)),
+        ('MediaWiki 1.24.0-wmf.1', (1, 24, 0, 'wmf', 1)),
         ('MediaWiki 1.24.1alpha', (1, 24, 1, 'alpha')),
-        ('MediaWiki 1.24.1alpha1', (1, 24, 1, 'alpha1')),
-        ('MediaWiki 1.24.1-rc.3', (1, 24, 1, '-rc', 3)),
+        ('MediaWiki 1.24.1alpha1', (1, 24, 1, 'alpha', 1)),
+        ('MediaWiki 1.24.1-rc.3', (1, 24, 1, 'rc', 3)),
     ])
     def test_version_tuple_from_generator(self, version, expected):
         assert mwclient.Site.version_tuple_from_generator(version) == expected


### PR DESCRIPTION
[In the MediaWiki documentation](https://www.mediawiki.org/wiki/Manual:$wgVersion#Example_code), versions are compared using [PHP's version_compare](https://www.php.net/manual/de/function.version-compare.php) function, which canonicalizes version strings by:

- Replacing _, -, and + with dots (.)
- Inserting dots before and after any non-numeric characters

The version string is then split on the dots, and the resulting segments are compared from left to right. This PR updates `Site.version_tuple_from_generator` to parse versions according to those rules.

Additionally, this PR:
- Adds a new check to `version_tuple_from_generator` to make sure that the first two elements in the resulting version tuple are always integers.
- Makes sure we consistently use `Site.require` instead of comparing versions manually.

---

**Note:** The new canonicalization rules and the updated check are technically breaking changes due to the function being public. However, for our internal usage nothing should change. For details, see to the test case changes in commit 3b6d83b.