### PR TITLE
Various documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ There is also some documentation on the [GitHub wiki](https://github.com/mwclien
 that hasn't been ported yet.
 If you want to help, you're welcome!
 
+## License
+
+mwclient is licensed under the MIT license. See the [LICENSE.md](LICENSE.md)
+file for details.
+
+## Versioning
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
 ## Contributing
 
 Patches are welcome! See [this page](https://mwclient.readthedocs.io/en/latest/development/)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,7 +81,23 @@ Looking for information on contributing to mwclient development?
 MIT License
 -----------
 
-    .. include:: ../../LICENSE.md
+This project is licensed under the MIT License. The full text of the license
+is reproduced below:
+
+    .. literalinclude:: ../../LICENSE.md
+        :language: text
+
+Versioning
+----------
+
+Mwclient uses `Semantic Versioning 2.0.0 <http://semver.org>`_. Versions are
+numbered ``MAJOR.MINOR.PATCH``. The version will be incremented based on the
+following:
+
+* `MAJOR` version is incremented when backwards incompatible changes are made.
+* `MINOR` version is incremented when functionality is added in a backwards
+  compatible manner.
+* `PATCH` version is incremented when backwards compatible bug fixes are made.
 
 Indices and tables
 ------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,9 +6,9 @@ mwclient: lightweight MediaWiki client
    :align: right
    :width: 30%
 
-Mwclient is a :ref:`MIT licensed <license>` client library to the `MediaWiki API`_
-that should work well with both Wikimedia wikis and other wikis running
-MediaWiki 1.16 or above. It works with Python 2.7 and 3.3+.
+Mwclient is an :ref:`MIT licensed <license>` client library for the `MediaWiki API`_
+that works well with both Wikimedia wikis and other wikis running
+MediaWiki 1.21 or above. It is compatible with Python 3.6 and above.
 
 .. _install:
 

--- a/docs/source/reference/errors.rst
+++ b/docs/source/reference/errors.rst
@@ -1,7 +1,9 @@
 .. _errors:
 
-:class:`InsufficientPermission`
+:mod:`Errors <mwclient.errors>`
 -------------------------------
 
-.. autoclass:: mwclient.errors.InsufficientPermission
+.. automodule:: mwclient.errors
    :members:
+   :undoc-members:
+   :show-inheritance:

--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -104,10 +104,6 @@ class NoSpecifiedEmail(EmailError):
     pass
 
 
-class NoWriteApi(MwClientError):
-    pass
-
-
 class InvalidResponse(MwClientError):
 
     def __init__(self, response_text=None):

--- a/mwclient/errors.py
+++ b/mwclient/errors.py
@@ -1,20 +1,31 @@
 class MwClientError(RuntimeError):
+    """Base class for all mwclient errors."""
     pass
 
 
 class MediaWikiVersionError(MwClientError):
+    """The version of MediaWiki is not supported."""
     pass
 
 
 class APIDisabledError(MwClientError):
+    """The API is disabled on the wiki."""
     pass
 
 
 class MaximumRetriesExceeded(MwClientError):
+    """The maximum number of retries for a request has been exceeded."""
     pass
 
 
 class APIError(MwClientError):
+    """Base class for errors returned by the MediaWiki API.
+
+    Attributes:
+        code (Optional[str]): The error code returned by the API.
+        info (str): The error message returned by the API.
+        kwargs (Optional[Any]): Additional information.
+    """
 
     def __init__(self, code, info, kwargs):
         self.code = code
@@ -23,18 +34,29 @@ class APIError(MwClientError):
 
 
 class InsufficientPermission(MwClientError):
+    """Raised when the user does not have sufficient permissions to perform an
+    action."""
     pass
 
 
 class UserBlocked(InsufficientPermission):
+    """Raised when attempting to perform an action while blocked."""
     pass
 
 
 class EditError(MwClientError):
+    """Base class for errors related to editing pages."""
     pass
 
 
 class ProtectedPageError(EditError, InsufficientPermission):
+    """Raised when attempting to edit a protected page.
+
+    Attributes:
+        page (mwclient.page.Page): The page for which the edit attempt was made.
+        code (Optional[str]): The error code returned by the API.
+        info (Optional[str]): The error message returned by the API.
+    """
 
     def __init__(self, page, code=None, info=None):
         self.page = page
@@ -52,6 +74,9 @@ class FileExists(EditError):
     Raised when trying to upload a file that already exists.
 
     See also: https://www.mediawiki.org/wiki/API:Upload#Upload_warnings
+
+    Attributes:
+        file_name (str): The name of the file that already exists.
     """
 
     def __init__(self, file_name):
@@ -65,6 +90,14 @@ class FileExists(EditError):
 
 
 class LoginError(MwClientError):
+    """Base class for login errors.
+
+    Attributes:
+        site (mwclient.site.Site): The site object on which the login attempt
+            was made.
+        code (str): The error code returned by the API.
+        info (str): The error message returned by the API.
+    """
 
     def __init__(self, site, code, info):
         super().__init__(
@@ -80,11 +113,19 @@ class LoginError(MwClientError):
 
 
 class OAuthAuthorizationError(LoginError):
+    """Raised when OAuth authorization fails.
+
+    Attributes:
+        site (mwclient.site.Site): The site object on which the login attempt
+            was made.
+        code (str): The error code returned by the API.
+        info (str): The error message returned by the API.
+    """
     pass
 
 
 class AssertUserFailedError(MwClientError):
-
+    """Raised when the user assertion fails."""
     def __init__(self):
         super().__init__(
             'By default, mwclient protects you from accidentally editing '
@@ -97,14 +138,21 @@ class AssertUserFailedError(MwClientError):
 
 
 class EmailError(MwClientError):
+    """Base class for email errors."""
     pass
 
 
 class NoSpecifiedEmail(EmailError):
+    """Raised when trying to email a user who has not specified an email"""
     pass
 
 
 class InvalidResponse(MwClientError):
+    """Raised when the server returns an invalid JSON response.
+
+    Attributes:
+        response_text (str): The response text from the server.
+    """
 
     def __init__(self, response_text=None):
         super().__init__((
@@ -120,4 +168,5 @@ class InvalidResponse(MwClientError):
 
 
 class InvalidPageTitle(MwClientError):
+    """Raised when an invalid page title is used."""
     pass

--- a/mwclient/image.py
+++ b/mwclient/image.py
@@ -4,6 +4,18 @@ import mwclient.page
 
 
 class Image(mwclient.page.Page):
+    """
+    Represents an image on a MediaWiki wiki represented by a
+    :class:`~mwclient.client.Site` object.
+
+    Args:
+        site (mwclient.client.Site): The site object this page belongs to.
+        name (Union[str, int, Page]): The title of the page, the page ID, or
+            another :class:`Page` object to copy.
+        info (Optional[dict]): Page info, if already fetched, e.g., when
+            iterating over a list of pages. If not provided, the page info
+            will be fetched from the API.
+    """
 
     def __init__(self, site, name, info=None):
         super().__init__(

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -188,6 +188,20 @@ class GeneratorList(List):
 
 
 class Category(mwclient.page.Page, GeneratorList):
+    """
+    Represents a category on a MediaWiki wiki represented by a
+    :class:`~mwclient.client.Site` object.
+
+    Args:
+        site (mwclient.client.Site): The site object this page belongs to.
+        name (Union[str, int, Page]): The title of the page, the page ID, or
+            another :class:`Page` object to copy.
+        info (Optional[dict]): Page info, if already fetched, e.g., when
+            iterating over a list of pages. If not provided, the page info
+            will be fetched from the API.
+        namespace (Union[int, str, None]): The namespace of the category
+            members to list.
+    """
 
     def __init__(self, site, name, info=None, namespace=None):
         mwclient.page.Page.__init__(self, site, name, info)

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -5,6 +5,30 @@ import mwclient.errors
 
 
 class Page:
+    """
+    Represents a page on a MediaWiki wiki represented by a
+    :class:`~mwclient.client.Site` object.
+
+    Args:
+        site (mwclient.client.Site): The site object this page belongs to.
+        name (Union[str, int, Page]): The title of the page, the page ID, or
+            another :class:`Page` object to copy.
+        info (Optional[dict]): Page info, if already fetched, e.g., when
+            iterating over a list of pages. If not provided, the page info
+            will be fetched from the API.
+        extra_properties (Optional[dict]): Extra properties to fetch when
+            initializing the page.
+
+    Examples:
+        >>> site = mwclient.Site('en.wikipedia.org')
+        >>> page1 = Page(site, 'Main Page')
+        >>> page2 = Page(site, 123456)
+        >>> page3 = Page(site, 'Main Page', extra_properties={
+        ...     'imageinfo': [
+        ...         ('iiprop', 'timestamp|user|comment|url|size|sha1|metadata'),
+        ...     ],
+        ... })
+    """
 
     def __init__(self, site, name, info=None, extra_properties=None):
         if type(name) is type(self):


### PR DESCRIPTION
This PR contains various improvements to the documentation (see individual commits).

* Adds documentation to the `Page`, `Image`, and `Category` constructors.
* Adds all errors to the documentation. Previously only `mwclient.errors.InsufficientPermission` was included.
* Update the required Python/MediaWiki versions in the docs.
* Add information about the version scheme/license