### PR TITLE
Allow passing `int` and `Page` objects to `PageList.get` and `__getitem__`

### DIFF
--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -391,7 +391,7 @@ class TestList(unittest.TestCase):
         assert mock_site.get.call_args[0] == ("query",)
         assert mock_site.get.call_args[1]["titles"] == "Impossible"
         # covers the catch of AttributeError in get()
-        pg = pl[8052484]  # type: ignore[index]
+        pg = pl[8052484]
         assert isinstance(pg, Page)
         assert mock_site.get.call_args[0] == ("query",)
         assert mock_site.get.call_args[1]["pageids"] == 8052484


### PR DESCRIPTION
The previous type-annotation was too narrow here (and even required a `type: ignore[index]`). `PageList.get` also works with `int` and `Page` objects.