### PR TITLE
Update page attributes after edit

### DIFF
--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -1,5 +1,5 @@
 from typing import (  # noqa: F401
-    Optional, Tuple, Any, Union, Iterator, Mapping, Iterable, Type
+    Optional, Tuple, Any, Union, Iterator, Mapping, Iterable, Type, Dict
 )
 
 import mwclient.image
@@ -237,7 +237,7 @@ class Category(mwclient.page.Page, GeneratorList):
         namespace: Optional[Namespace] = None
     ) -> None:
         mwclient.page.Page.__init__(self, site, name, info)
-        kwargs = {}
+        kwargs = {}  # type: Dict[str, Any]
         kwargs['gcmtitle'] = self.name
         if namespace:
             kwargs['gcmnamespace'] = namespace

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -390,8 +390,15 @@ class Page:
             data['movesubpages'] = '1'
         if ignore_warnings:
             data['ignorewarnings'] = '1'
+
         result = self.site.post('move', ('from', self.name), to=new_title,
                                 token=self.get_token('move'), reason=reason, **data)
+
+        if 'redirectcreated' in result['move']:
+            self.redirect = True
+        else:
+            self.exists = False
+
         return result['move']
 
     def delete(
@@ -418,9 +425,12 @@ class Page:
             data['unwatch'] = '1'
         if oldimage:
             data['oldimage'] = oldimage
+
         result = self.site.post('delete', title=self.name,
                                 token=self.get_token('delete'),
                                 reason=reason, **data)
+
+        self.exists = False
         return result['delete']
 
     def purge(self) -> None:


### PR DESCRIPTION
As discussed in #354, this change updates the page attributes without extra API calls after each (successful) call to `Page._edit` and its upstream functions (`Page.save`, `Page.edit`, `Page.append`, `Page.prepend`, and `Page.touch`). This is more or less what I suggested in [this comment](https://github.com/mwclient/mwclient/issues/354#issuecomment-2317762162).

@AdamWill [you mentioned](https://github.com/mwclient/mwclient/issues/354#issuecomment-2318077642) having an alternative patch lying around. I've checked the "Allow edits and access to secrets by maintainers" option, so you should be able to push to this branch if you have any changes/improvements over this.

resolves #354, resolves #63