### PR TITLE
Add Python 3.13 classifier and start testing with 3.14-alpha

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,7 +18,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13.0-alpha - 3.13"
+          - "3.13"
+          - "3.14.0-alpha - 3.14"
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-22.04"
@@ -41,8 +42,8 @@ jobs:
       - name: Test with tox
         run: tox
       - name: Produce coverage.lcov for coveralls
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         run: coverage lcov
       - name: Coveralls
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         uses: coverallsapp/github-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,py313,flake,mypy
+envlist = py36,py37,py38,py39,py310,py311,py312,py313,py314,flake,mypy
 isolated_build = true
 
 [gh-actions]
@@ -10,8 +10,9 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    3.12: py312, flake, integration, mypy
-    3.13: py313
+    3.12: py312
+    3.13: py313, flake, integration, mypy
+    3.14: py314
 
 [testenv]
 extras = testing


### PR DESCRIPTION
This PR adds the `Programming Language :: Python :: 3.13` classifier to `setup.py`. It also updates the Python version used for running tests, linting, and mypy to 3.13, and adds Python 3.14.0-alpha to the Tox configuration. 

We should wait until actions/python-versions#312 is merged before proceeding with this PR, as the CI will fail until then.