### PR TITLE
Replace `pkg_resources` with `importlib.metadata` for Python 3.8+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ testing = [
     "pytest-cov",
     "responses>=0.3.0",
     "responses!=0.6.0",
-    "setuptools",
+    "setuptools; python_version < '3.8'",
 ]
 
 [project.urls]

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,11 +1,11 @@
 import json
 import logging
+import sys
 import time
 import unittest
 import unittest.mock as mock
 from io import BytesIO
 
-import pkg_resources  # part of setuptools
 import pytest
 import requests
 import responses
@@ -125,7 +125,15 @@ class TestClient(TestCase):
 
     def testVersion(self):
         # The version specified in setup.py should equal the one specified in client.py
-        version = pkg_resources.require("mwclient")[0].version
+
+        if sys.version_info >= (3, 8):
+            import importlib.metadata
+
+            version = importlib.metadata.version("mwclient")
+        else:
+            import pkg_resources  # part of setuptools
+
+            version = pkg_resources.require("mwclient")[0].version
 
         assert version == mwclient.__version__
 


### PR DESCRIPTION
This change replaces the deprecated `pkg_resources` (part of `setuptools`) with `importlib.metadata` for Python 3.8 and above.

Switching to `importlib.metadata` allows us to drop the test-dependency on `setuptools` and gets rid of the `DeprecationWarning` raised by certain versions of `pkg_resources` when being imported:

```
DeprecationWarning: pkg_resources is deprecated as an API
```