### PR TITLE
Hard-code ubuntu-22.04 for Python 3.7 CI jobs

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,8 @@ jobs:
           - "3.13.0-alpha - 3.13"
         include:
           - os: "ubuntu-latest"
+          - os: "ubuntu-22.04"
+            python-version: "3.7"
           - os: "ubuntu-20.04"
             python-version: "3.6"
 


### PR DESCRIPTION
ubuntu-latest is in the process of being updated from ubuntu-22.04 to ubuntu-24.04, which leads to issues with py37:

```
Version 3.7 was not found in the local cache
Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```

This commit hard-codes the ubuntu-version for py37 to ubuntu-22.04, similar to what we've done for py36.

See actions/runner-images#10636 for more information.