### PR TITLE
test: remove pytest.ini_options from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,6 @@ Repository = "https://github.com/mwclient/mwclient"
 Issues = "https://github.com/mwclient/mwclient/issues"
 Changelog = "https://github.com/mwclient/mwclient/releases"
 
-[tool.pytest.ini_options]
-addopts = "--cov=mwtp --cov-report=html --color=yes"
-testpaths = [
-    "test"
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
These options were removed in 96dea32 but were unintentionally reintroduced in #360 as part of 859f3ee. This can cause issues in certain CI environments (see #340). Additionally, the module name after `--cov` is incorrect, resulting in the following warning:

```
CoverageWarning: Module mwtp was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
```