### PR TITLE
Update `Site.expandtemplates` to use the new API added in 1.24

### DIFF
--- a/test/integration.py
+++ b/test/integration.py
@@ -6,9 +6,9 @@ from typing import Optional
 from urllib.error import URLError, HTTPError
 from urllib.request import urlopen
 
-import mwclient
 import pytest
 
+import mwclient
 
 if shutil.which("podman"):
     _CONTAINER_RUNTIME = "podman"
@@ -104,6 +104,17 @@ class TestAnonymous:
         pg = site.pages["Anonymous New Page"]
         with pytest.raises(mwclient.errors.ProtectedPageError):
             pg.edit("Hi I'm a new page", "create new page")
+
+    def test_expandtemplates(self, site):
+        """Test we can expand templates."""
+        wikitext = site.expandtemplates("{{CURRENTYEAR}}")
+        assert wikitext == str(time.localtime().tm_year)
+
+    def test_expandtemplates_with_parsetree(self, site):
+        """Test we can expand templates and get the parse tree."""
+        wikitext, parsetree = site.expandtemplates("{{CURRENTYEAR}}", generatexml=True)
+        assert wikitext == str(time.localtime().tm_year)
+        assert parsetree == "<root><template><title>CURRENTYEAR</title></template></root>"
 
 class TestLogin:
     def test_login_wrong_password(self, site):


### PR DESCRIPTION
Refactored `Site.expandtemplates` to use the updated API, addressing deprecation warnings in recent MediaWiki versions.

The older API triggered the following warnings:

```
WARNING:mwclient.client:Subscribe to the mediawiki-api-announce mailing list at <https://lists.wikimedia.org/postorius/lists/mediawiki-api-announce.lists.wikimedia.org/> for notice of API deprecations and breaking changes. Use [[Special:ApiFeatureUsage]] to see usage of deprecated features by your application.
WARNING:mwclient.client:The parameter "generatexml" has been deprecated.
Because "prop" was not specified, a legacy format has been used for the output. This format is deprecated, and in the future the new format will always be used.
```