### PR TITLE
Update documentation config and dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   configuration: docs/source/conf.py
@@ -12,4 +12,5 @@ python:
   install:
     - method: pip
       path: .
-    - requirements: docs/requirements.txt
+      extra_requirements:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-sphinx==7.2.5
-sphinx_rtd_theme==1.3.0

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -94,7 +94,7 @@ To build the documentation locally for testing:
 
 .. code:: bash
 
-    $ pip install -r docs/requirements.txt
+    $ pip install -e '.[docs]'
     $ cd docs
     $ make html
 

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -85,21 +85,75 @@ If you would like to expand the test suite by adding more tests, please go ahead
 Updating/expanding the documentation
 ------------------------------------
 
-Documentation consists of both a manually compiled user guide
-(under ``docs/user``) and a reference guide generated from the docstrings,
-using Sphinx autodoc with the napoleon extension.
-Documentation is built automatically on `ReadTheDocs <https://mwclient.readthedocs.io/>`_
-after each commit.
-To build the documentation locally for testing:
+The documentation for this project consists of two main parts:
 
-.. code:: bash
+1. A manually compiled user guide (located in ``docs/user/``).
+2. A reference guide automatically generated from docstrings using Sphinx
+   autodoc with the napoleon extension.
 
-    $ pip install -e '.[docs]'
-    $ cd docs
-    $ make html
+Builds
+^^^^^^
+
+Automatic Builds
+""""""""""""""""
+
+Documentation is automatically built on `ReadTheDocs <https://mwclient.readthedocs.io/>`_
+after each commit. The configuration for this can be found in ``.readthedocs.yaml``.
+
+Local Builds
+""""""""""""
+
+To build and test the documentation on your local machine:
+
+1. Install the documentation dependencies:
+
+    .. code:: bash
+
+        $ pip install -e '.[docs]'
+
+2. Build the documentation:
+
+    .. code:: bash
+
+        $ cd docs
+        $ make html
+
+The generated HTML documentation will be available in ``docs/build/html/``.
+Open ``docs/build/html/index.html`` in your browser to view it.
+
+If you make
+changes to the documentation, you can rebuild it by running ``make html``
+again and then refreshing the page in your browser. To rebuild after making
+changes, run ``make html`` again and refresh your browser.
+
+Writing Docstrings
+^^^^^^^^^^^^^^^^^^
 
 When writing docstrings, try to adhere to the
 `Google style <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_.
+For example:
+
+.. code:: python
+
+    def my_function(foo: str) -> str:
+        """This is a function that does something.
+
+        Args:
+            foo: A string to do something with.
+
+        Returns:
+            A string with the result.
+        """
+
+
+You can also use `Sphinx-specific directives <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html>`_
+in your docstrings to provide additional information. Some useful directives
+include:
+
+    - ``.. warning ::``: Highlight potential issues.
+    - ``.. note ::``: Provide additional information.
+    - ``.. seealso ::``: Link to related documentation.
+    - ``.. deprecated ::``: Mark a function as deprecated.
 
 Making a pull request
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+docs = [
+    "sphinx",
+    "sphinx-rtd-theme",
+]
 testing = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This PR moves the dependencies required to build the docs from `docs/requirements.txt` to the `pyproject.toml` and updated the build os/python version.

It also updates the "Updating/expanding the documentation" section of the documentation with the new build commands and adds some more information.