### PR TITLE
Please whitelist requesting createaccount tokens in get_token

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -970,7 +970,14 @@ class Site:
         if self.version is None or self.require(1, 24, raise_error=False):
             # The 'csrf' (cross-site request forgery) token introduced in 1.24 replaces
             # the majority of older tokens, like edittoken and movetoken.
-            if type not in {'watch', 'patrol', 'rollback', 'userrights', 'login'}:
+            if type not in {
+                'watch',
+                'patrol',
+                'rollback',
+                'userrights',
+                'login',
+                'createaccount',
+            }:
                 type = 'csrf'
 
         if type not in self.tokens:


### PR DESCRIPTION
Hi

According to the API documentation for MediaWiki we still seem to need the `createaccount`-tokens to add user accounts to the wiki: https://www.mediawiki.org/wiki/API:Account_creation#Python.

Could you whitelist the `createaccount` token requests, please?

Regards,
  Oliver