### PR TITLE
ci: pin third-party GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5.5.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v5.5.0
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
 
@@ -44,7 +44,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
   github-release:
     name: Sign the distribution with Sigstore and upload as a GitHub Release
@@ -64,7 +64,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
     - name: Create GitHub Release

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.5.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -46,4 +46,4 @@ jobs:
         run: coverage lcov
       - name: Coveralls
         if: matrix.python-version == '3.13'
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6


### PR DESCRIPTION
This PR pins all third-party GitHub Actions to specific commit hashes. This helps prevent supply chain attacks, like CVE-2025-30066, where a tag is updated with malicious code. Dependabot will still create PRs for new versions, but that at least gives us a chance to review changes before merging.