### PR TITLE
Drop Python 3.6 Support; Require Python >=3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -24,8 +23,6 @@ jobs:
           - os: "ubuntu-latest"
           - os: "ubuntu-22.04"
             python-version: "3.7"
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 mwclient is a lightweight Python client library to the
 [MediaWiki API](https://mediawiki.org/wiki/API)
 which provides access to most API functionality.
-It works with Python 3.6 and above,
+It works with Python 3.7 and above,
 and supports MediaWiki 1.21 and above.
 For functions not available in the current MediaWiki,
 a `MediaWikiVersionError` is raised.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ mwclient: lightweight MediaWiki client
 
 Mwclient is an :ref:`MIT licensed <license>` client library for the `MediaWiki API`_
 that works well with both Wikimedia wikis and other wikis running
-MediaWiki 1.21 or above. It is compatible with Python 3.6 and above.
+MediaWiki 1.21 or above. It is compatible with Python 7 and above.
 
 .. _install:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mwclient"
 dynamic = ["version"]
 description = "MediaWiki API client"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 authors = [
     { name = "Bryan Tong Minh", email = "bryan.tongminh@gmail.com" },
 ]
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,py313,py314,flake,mypy
+envlist = py37,py38,py39,py310,py311,py312,py313,py314,flake,mypy
 isolated_build = true
 
 [gh-actions]


### PR DESCRIPTION
GitHub has deprecated the `ubuntu-20.04` runner, which was the last image supporting Python 3.6: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

Additionally, actions/setup-python will not be updated to support Python 3.6 going forward: actions/setup-python#1048

As a result, Python 3.6 is no longer easily testable and I've removed it from the matrix.

@mwclient/maintainers we should decide whether to drop support for Python 3.6 entirely (given that it's EOL for 3+ years), or at least update the documentation to mention that it's not tested in CI and only supported on a best-effort basis.