### PR TITLE
Update documentation for the Site constructor `pool` parameter

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -37,7 +37,9 @@ class Site:
             located). Must contain a trailing slash (`/`). Defaults to `/w/`.
         ext: The file extension used by the MediaWiki API scripts. Defaults to `.php`.
         pool: A preexisting :class:`~requests.Session` to be used when executing API
-            requests.
+            requests. When this is set, the `client_certificate`, `clients_useragent`,
+            `custom_headers`, `http_auth` and all OAuth related parameters are all
+            ignored.
         retry_timeout: The number of seconds to sleep for each past retry of a failing API
             request. Defaults to `30`.
         max_retries: The maximum number of retries to perform for failing API requests.


### PR DESCRIPTION
We recently had a bug where we weren't sending our custom User-Agent to the WMF servers. The source of this bug was the fact that we were using the `pool` parameter in the `Site` constructor, and therefore `clients_useragent` was being silently ignored.

In lieu of issuing warnings or throwing errors in this situation, this PR simply updates the docs so that future users will have a better chance of figuring out this situation without needing to read the code directly.