### PR TITLE
Specify limited permissions for CI actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,8 @@ on: ["push", "pull_request"]
 jobs:
   build:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     strategy:
       max-parallel: 4
       fail-fast: false

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,6 +6,8 @@ on: ["push", "pull_request"]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       max-parallel: 4
       fail-fast: false


### PR DESCRIPTION
We previously had "Read and write permissions" enabled for the repo, which was not a good idea (it means any Action can do almost anything to the project). I've changed that to "Read repository contents and packages permissions", which makes the default permissions more restricted.

The docs aren't great, but I *think* explicitly specifying the permissions for these individual actions tightens them down further (i.e. this will make it so these actions can *only* read the repo contents, nothing else). Let's see if they still work.

The 'release' workflow already has appropriate permissions set, by the looks of it.