### PR TITLE
Fix warning and crash in Site.revisions (#389)

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1709,6 +1709,7 @@ class Site:
         self,
         revids: List[Union[int, str]],
         prop: str = 'ids|timestamp|flags|comment|user',
+        slots: str = 'main',
     ) -> List[Dict[str, Any]]:
         """Get data about a list of revisions.
 
@@ -1733,6 +1734,9 @@ class Site:
             'rvprop': prop,
             'revids': '|'.join(map(str, revids))
         }
+        if self.version[:2] > (1, 31):  # type: ignore[index]
+            # https://github.com/mwclient/mwclient/issues/389
+            kwargs['rvslots'] = slots
 
         revisions = []
         pages = self.get('query', **kwargs).get('query', {}).get('pages', {}).values()
@@ -1740,7 +1744,8 @@ class Site:
             for revision in page.get('revisions', ()):
                 revision['pageid'] = page.get('pageid')
                 revision['pagetitle'] = page.get('title')
-                revision['timestamp'] = parse_timestamp(revision['timestamp'])
+                if 'timestamp' in revision:
+                    revision['timestamp'] = parse_timestamp(revision['timestamp'])
                 revisions.append(revision)
         return revisions
 

--- a/test/integration.py
+++ b/test/integration.py
@@ -1,4 +1,5 @@
 import http.client
+import logging
 import shutil
 import subprocess
 import time
@@ -162,7 +163,7 @@ class TestLogin:
         assert pg.exists == False
 
 
-class TestClientLogin:
+class TestClient:
     def test_clientlogin_wrong_password(self, site):
         """Test we raise correct error for clientlogin() with wrong password."""
         with pytest.raises(mwclient.errors.LoginError):
@@ -180,6 +181,19 @@ class TestClientLogin:
         pg.edit("Hi I'm a new page", "create new page")
         pg = site.pages["Anonymous New Page"]
         assert pg.text() == "Hi I'm a new page"
+
+    def test_site_revisions(self, site, caplog):
+        caplog.set_level(logging.WARNING)
+        # as per docstring example, make sure we don't crash for lack
+        # of timestamp here
+        rev = site.revisions([1], prop="content")[0]
+        assert rev["pagetitle"] == "Main Page"
+        # without limiting response
+        rev = site.revisions([1])[0]
+        assert rev["pagetitle"] == "Main Page"
+        # check timestamp parsing
+        assert isinstance(rev["timestamp"], time.struct_time)
+        assert not caplog.text
 
 
 class TestUploadAsync:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -724,7 +724,6 @@ class TestClientApiMethods(TestCase):
                     'comment': 'Test comment 1'
                 }, {
                     'revid': 689816909,
-                    'timestamp': '2015-11-09T16:09:28Z',
                     'comment': 'Test comment 2'
                 }]
             }}}}


### PR DESCRIPTION
This should fix the deprecation warning reported in #389, though I am so far unable to reproduce it. The fix follows the same pattern as the one for Page.revisions.

This also fixes mwclient throwing a KeyError if you call Site.revisions with a props argument that does not include timestamp. This was broken by c23abae , which didn't guard against 'timestamp' not being in the response.