### PR TITLE
Update docs to clarify we only support OAuth 1 currently (#395)

### DIFF
--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -115,8 +115,11 @@ unauthenticated, just set
 
 .. _oauth:
 
-OAuth Authentication
-^^^^^^^^^^^^^^^^^^^^
+OAuth 1 Authentication
+^^^^^^^^^^^^^^^^^^^^^^
+
+Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
+upstream documentation, please refer to the OAuth 1 section.
 
 On Wikimedia wikis, the recommended authentication method is to authenticate as
 a `owner-only consumer`_. Once you have obtained the *consumer token* (also


### PR DESCRIPTION
Update the documentation to clarify mwclient currently supports only OAuth 1 (thanks, @ragesoss).

Adding OAuth 2 probably shouldn't be very hard, I'll try and find some time to look at it soon.