### PR TITLE
Update tox/CI config for Python 3.14/3.15

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,8 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14.0-alpha - 3.14"
+          - "3.14"
+          - "3.15.0-alpha - 3.15"
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-22.04"
@@ -41,8 +42,8 @@ jobs:
       - name: Test with tox
         run: tox
       - name: Produce coverage.lcov for coveralls
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         run: coverage lcov
       - name: Coveralls
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,py312,py313,py314,flake,mypy
+envlist = py37,py38,py39,py310,py311,py312,py313,py314,py315,flake,mypy
 isolated_build = true
 
 [gh-actions]
@@ -10,8 +10,9 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
-    3.13: py313, flake, integration, mypy
-    3.14: py314
+    3.13: py313
+    3.14: py314, flake, integration, mypy
+    3.15: py315
 
 [testenv]
 extras = testing


### PR DESCRIPTION
3.14 is final now (so bump all the things that run on 'current Python' to that), and 3.15 alphas are available (so add testing on those).