### PR TITLE
Update OAuth docs to be user-only agnostic.

### DIFF
--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -125,7 +125,7 @@ Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
 upstream documentation, please refer to the OAuth 1 section.
 
 On Wikimedia wikis, the recommended authentication method is to use OAuth.
-OAuth credentials (`consumers``) can be optionally be created as `owner-only`,
+OAuth credentials (`consumers`) can be optionally be created as `owner-only`,
 a simplified way for bots and tools which only ever need to use a single account.
 Either type works with mwclient. Once you have obtained the *consumer token*
 (also called *consumer key*), the *consumer secret*, the *access token* and the

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -124,9 +124,11 @@ OAuth 1 Authentication
 Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
 upstream documentation, please refer to the OAuth 1 section.
 
-On Wikimedia wikis, OAuth consumers can optionally be created as `owner-only`;
-either type works with mwclient. Once you have obtained the *consumer token* (also
-called *consumer key*), the *consumer secret*, the *access token* and the
+On Wikimedia wikis, the recommended authentication method is to use OAuth.
+OAuth credentials ('consumers') can be optionally be created as `owner-only`,
+a simplified way for bots and tools which only ever need to use a single account.
+Either type works with mwclient. Once you have obtained the *consumer token*
+(also called *consumer key*), the *consumer secret*, the *access token* and the
 *access secret*, you can authenticate like so:
 
     >>> site = Site('test.wikipedia.org',
@@ -136,7 +138,8 @@ called *consumer key*), the *consumer secret*, the *access token* and the
                     access_secret='my_access_secret')
 
 
-.. _MediaWiki OAuth docs: https://www.mediawiki.org/wiki/OAuth
+.. _General MediaWiki OAuth docs: https://www.mediawiki.org/wiki/OAuth
+.. _owner-only consumer: https://www.mediawiki.org/wiki/OAuth/Owner-only_consumers
 
 .. _clientlogin:
 

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -125,7 +125,7 @@ Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
 upstream documentation, please refer to the OAuth 1 section.
 
 On Wikimedia wikis, the recommended authentication method is to use OAuth.
-OAuth credentials (`consumers`) can optionally be created as `owner-only`,
+OAuth credentials can optionally be created as an `owner-only consumer`_,
 a simplified way for bots and tools which only ever need to use a single account;
 either type works with mwclient. Once you have obtained the *consumer token*
 (also called *consumer key*), the *consumer secret*, the *access token* and the
@@ -138,7 +138,6 @@ either type works with mwclient. Once you have obtained the *consumer token*
                     access_secret='my_access_secret')
 
 
-.. _General MediaWiki OAuth docs: https://www.mediawiki.org/wiki/OAuth
 .. _owner-only consumer: https://www.mediawiki.org/wiki/OAuth/Owner-only_consumers
 
 .. _clientlogin:

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -124,8 +124,8 @@ OAuth 1 Authentication
 Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
 upstream documentation, please refer to the OAuth 1 section.
 
-On Wikimedia wikis, the recommended authentication method is to authenticate as
-a `owner-only consumer`_. Once you have obtained the *consumer token* (also
+On Wikimedia wikis, OAuth consumers can optionally be created as `owner-only`;
+either type works with mwclient. Once you have obtained the *consumer token* (also
 called *consumer key*), the *consumer secret*, the *access token* and the
 *access secret*, you can authenticate like so:
 
@@ -136,7 +136,7 @@ called *consumer key*), the *consumer secret*, the *access token* and the
                     access_secret='my_access_secret')
 
 
-.. _owner-only consumer: https://www.mediawiki.org/wiki/OAuth/Owner-only_consumers
+.. _MediaWiki OAuth docs: https://www.mediawiki.org/wiki/OAuth
 
 .. _clientlogin:
 

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -125,7 +125,7 @@ Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
 upstream documentation, please refer to the OAuth 1 section.
 
 On Wikimedia wikis, the recommended authentication method is to use OAuth.
-OAuth credentials (`consumers`) can be optionally be created as `owner-only`,
+OAuth credentials (`consumers`) can optionally be created as `owner-only`,
 a simplified way for bots and tools which only ever need to use a single account.
 Either type works with mwclient. Once you have obtained the *consumer token*
 (also called *consumer key*), the *consumer secret*, the *access token* and the

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -126,8 +126,8 @@ upstream documentation, please refer to the OAuth 1 section.
 
 On Wikimedia wikis, the recommended authentication method is to use OAuth.
 OAuth credentials (`consumers`) can optionally be created as `owner-only`,
-a simplified way for bots and tools which only ever need to use a single account.
-Either type works with mwclient. Once you have obtained the *consumer token*
+a simplified way for bots and tools which only ever need to use a single account;
+either type works with mwclient. Once you have obtained the *consumer token*
 (also called *consumer key*), the *consumer secret*, the *access token* and the
 *access secret*, you can authenticate like so:
 

--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -125,7 +125,7 @@ Currently, mwclient does not support OAuth 2, only OAuth 1. When reading the
 upstream documentation, please refer to the OAuth 1 section.
 
 On Wikimedia wikis, the recommended authentication method is to use OAuth.
-OAuth credentials ('consumers') can be optionally be created as `owner-only`,
+OAuth credentials (`consumers``) can be optionally be created as `owner-only`,
 a simplified way for bots and tools which only ever need to use a single account.
 Either type works with mwclient. Once you have obtained the *consumer token*
 (also called *consumer key*), the *consumer secret*, the *access token* and the

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -68,10 +68,10 @@ class Site:
         connection_options: Additional arguments to be passed to the
             :py:meth:`requests.Session.request` method when performing API calls. If the
             `timeout` key is empty, a default timeout of 30 seconds is added.
-        consumer_token: OAuth1 consumer key for owner-only consumers.
-        consumer_secret: OAuth1 consumer secret for owner-only consumers.
-        access_token: OAuth1 access key for owner-only consumers.
-        access_secret: OAuth1 access secret for owner-only consumers.
+        consumer_token: OAuth1 consumer key.
+        consumer_secret: OAuth1 consumer secret.
+        access_token: OAuth1 access key.
+        access_secret: OAuth1 access secret.
         client_certificate: A client certificate to be added
             to the session.
         custom_headers: A dictionary of custom headers to be added to all


### PR DESCRIPTION
The current docs recommend user-only consumers and imply that those are the only kind which work.  In reality, multi-user consumers work just fine.