### PR TITLE
Support prefetching content for page lists

### DIFF
--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1354,7 +1354,8 @@ class Site:
         generator: bool = True,
         end: Optional[str] = None,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> listing.List:
         """
         Retrieve all pages on the wiki as a generator.
@@ -1363,13 +1364,19 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        pfx = listing.List.get_prefix('ap', generator)
-        kwargs = dict(listing.List.generate_kwargs(
-            pfx, ('from', start), ('to', end), prefix=prefix,
-            minsize=minsize, maxsize=maxsize, prtype=prtype, prlevel=prlevel,
-            namespace=namespace, filterredir=filterredir, dir=dir,
-            filterlanglinks=filterlanglinks,
-        ))
+
+        kwargs = listing.List.get_page_listing_args('ap', generator, with_content, {
+            'from': start,
+            'to': end,
+            'minsize': minsize,
+            'maxsize': maxsize,
+            'prtype': prtype,
+            'prlevel': prlevel,
+            'namespace': namespace,
+            'filterredir': filterredir,
+            'dir': dir,
+            'filterlanglinks': filterlanglinks
+        })
         return listing.List.get_list(generator)(self, 'allpages', 'ap',
                                                 max_items=max_items,
                                                 api_chunk_size=api_chunk_size,
@@ -1389,7 +1396,8 @@ class Site:
         generator: bool = True,
         end: Optional[str] = None,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> listing.List:
         """
         Retrieve all images on the wiki as a generator.
@@ -1398,12 +1406,16 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        pfx = listing.List.get_prefix('ai', generator)
-        kwargs = dict(listing.List.generate_kwargs(
-            pfx, ('from', start), ('to', end), prefix=prefix,
-            minsize=minsize, maxsize=maxsize,
-            dir=dir, sha1=sha1, sha1base36=sha1base36
-        ))
+
+        kwargs = listing.List.get_page_listing_args('ai', generator, with_content, {
+            'from': start,
+            'to': end,
+            'minsize': minsize,
+            'maxsize': maxsize,
+            'dir': dir,
+            'sha1': sha1,
+            'sha1base36': sha1base36
+        })
         return listing.List.get_list(generator)(self, 'allimages', 'ai',
                                                 max_items=max_items,
                                                 api_chunk_size=api_chunk_size,
@@ -1421,7 +1433,8 @@ class Site:
         generator: bool = True,
         end: Optional[str] = None,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> listing.List:
         """
         Retrieve a list of all links on the wiki as a generator.
@@ -1430,12 +1443,16 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        pfx = listing.List.get_prefix('al', generator)
-        kwargs = dict(listing.List.generate_kwargs(pfx, ('from', start), ('to', end),
-                                                   prefix=prefix,
-                                                   prop=prop, namespace=namespace))
-        if unique:
-            kwargs[pfx + 'unique'] = '1'
+
+        kwargs = listing.List.get_page_listing_args('al', generator, with_content, {
+            'from': start,
+            'to': end,
+            'prefix': prefix,
+            'prop': prop,
+            'namespace': namespace,
+            'unique': '1' if unique else False
+        })
+
         return listing.List.get_list(generator)(self, 'alllinks', 'al',
                                                 max_items=max_items,
                                                 api_chunk_size=api_chunk_size,
@@ -1450,7 +1467,8 @@ class Site:
         generator: bool = True,
         end: Optional[str] = None,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> listing.List:
         """
         Retrieve all categories on the wiki as a generator.
@@ -1459,9 +1477,14 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        pfx = listing.List.get_prefix('ac', generator)
-        kwargs = dict(listing.List.generate_kwargs(pfx, ('from', start), ('to', end),
-                                                   prefix=prefix, dir=dir))
+
+        kwargs = listing.List.get_page_listing_args('ac', generator, with_content, {
+            'from': start,
+            'to': end,
+            'prefix': prefix,
+            'dir': dir
+        })
+
         return listing.List.get_list(generator)(self, 'allcategories', 'ac',
                                                 max_items=max_items,
                                                 api_chunk_size=api_chunk_size, **kwargs)
@@ -1487,12 +1510,18 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('au', ('from', start), ('to', end),
-                                                   prefix=prefix,
-                                                   group=group, prop=prop,
-                                                   rights=rights,
-                                                   witheditsonly=witheditsonly,
-                                                   activeusers=activeusers))
+
+        kwargs = listing.List.get_listing_args('au', False, {
+            'from': start,
+            'to': end,
+            'prefix': prefix,
+            'group': group,
+            'prop': prop,
+            'rights': rights,
+            'witheditsonly': witheditsonly,
+            'activeusers': activeusers
+        })
+
         return listing.List(self, 'allusers', 'au', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1534,8 +1563,15 @@ class Site:
 
         # TODO: Fix. Fix what?
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('bk', start=start, end=end, dir=dir,
-                                                   ids=ids, users=users, prop=prop))
+
+        kwargs = listing.List.get_listing_args('bk', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'ids': ids,
+            'users': users,
+            'prop': prop
+        })
         return listing.List(self, 'blocks', 'bk', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1557,8 +1593,14 @@ class Site:
         """
         # TODO: Fix
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('dr', start=start, end=end, dir=dir,
-                                                   namespace=namespace, prop=prop))
+
+        kwargs = listing.List.get_listing_args('dr', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'namespace': namespace,
+            'prop': prop,
+        })
         return listing.List(self, 'deletedrevs', 'dr', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1596,9 +1638,13 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('eu', query=query, prop=prop,
-                                                   protocol=protocol,
-                                                   namespace=namespace))
+
+        kwargs = listing.List.get_listing_args('eu', False, {
+            'query': query,
+            'protocol': protocol,
+            'namespace': namespace,
+            'prop': prop,
+        })
         return listing.List(self, 'exturlusage', 'eu', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1621,9 +1667,17 @@ class Site:
 
         API doc: https://www.mediawiki.org/wiki/API:Logevents
         """
-        kwargs = dict(listing.List.generate_kwargs('le', prop=prop, type=type,
-                                                   start=start, end=end, dir=dir,
-                                                   user=user, title=title, action=action))
+
+        kwargs = listing.List.get_listing_args('le', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'type': type,
+            'user': user,
+            'title': title,
+            'action': action,
+            'prop': prop,
+        })
         return listing.List(self, 'logevents', 'le', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1641,8 +1695,14 @@ class Site:
         """Retrieve checkuserlog items as a generator."""
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('cul', target=target, start=start,
-                                                   end=end, dir=dir, user=user))
+
+        kwargs = listing.List.get_listing_args('cul', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'target': target,
+            'user': user
+        })
         return listing.NestedList(
             'entries',
             self,
@@ -1674,7 +1734,9 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('rn', namespace=namespace))
+        kwargs = listing.List.get_listing_args('rn', False, {
+            'namespace': namespace,
+        })
         return listing.List(self, 'random', 'rn', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1698,10 +1760,17 @@ class Site:
         API doc: https://www.mediawiki.org/wiki/API:Recentchanges
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('rc', start=start, end=end, dir=dir,
-                                                   namespace=namespace, prop=prop,
-                                                   show=show, type=type,
-                                                   toponly='1' if toponly else None))
+
+        kwargs = listing.List.get_listing_args('rc', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'namespace': namespace,
+            'prop': prop,
+            'show': show,
+            'type': type,
+            'toponly': '1' if toponly else None
+        })
         return listing.List(self, 'recentchanges', 'rc', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1784,10 +1853,14 @@ class Site:
             mwclient.listings.List: Search results iterator
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('sr', search=search,
-                                                   namespace=namespace, what=what))
-        if redirects:
-            kwargs['srredirects'] = '1'
+
+        kwargs = listing.List.get_listing_args('sr', False, {
+            'search': search,
+            'namespace': namespace,
+            'what': what,
+            'redirects': '1' if redirects else None
+        })
+
         return listing.List(self, 'search', 'sr', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 
@@ -1811,9 +1884,16 @@ class Site:
         API doc: https://www.mediawiki.org/wiki/API:Usercontribs
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('uc', user=user, start=start, end=end,
-                                                   dir=dir, namespace=namespace,
-                                                   prop=prop, show=show))
+
+        kwargs = listing.List.get_listing_args('uc', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'namespace': namespace,
+            'prop': prop,
+            'show': show,
+            'user': user
+        })
         return listing.List(self, 'usercontribs', 'uc', max_items=max_items,
                             api_chunk_size=api_chunk_size, uselang=uselang, **kwargs)
 
@@ -1850,11 +1930,17 @@ class Site:
         """
 
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(listing.List.generate_kwargs('wl', start=start, end=end,
-                                                   namespace=namespace, dir=dir,
-                                                   prop=prop, show=show))
-        if allrev:
-            kwargs['wlallrev'] = '1'
+
+        kwargs = listing.List.get_listing_args('wl', False, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'namespace': namespace,
+            'prop': prop,
+            'show': show,
+            'allrev': '1' if allrev else None
+        })
+
         return listing.List(self, 'watchlist', 'wl', max_items=max_items,
                             api_chunk_size=api_chunk_size, **kwargs)
 

--- a/mwclient/image.py
+++ b/mwclient/image.py
@@ -57,20 +57,25 @@ class Image(mwclient.page.Page):
         limit: Optional[int] = None,
         generator: bool = True,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> 'mwclient.listing.List':
         """
         List pages that use the given file.
 
         API doc: https://www.mediawiki.org/wiki/API:Imageusage
         """
-        prefix = mwclient.listing.List.get_prefix('iu', generator)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(
-            prefix, title=self.name, namespace=namespace, filterredir=filterredir
-        ))
+
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        if redirect:
-            kwargs[f'{prefix}redirect'] = '1'
+
+        kwargs = mwclient.listing.List.get_page_listing_args(
+            'iu', generator, with_content, {
+                'title': self.name,
+                'namespace': namespace,
+                'filterredir': filterredir,
+                'redirect': '1' if redirect else None
+            })
+
         return mwclient.listing.List.get_list(generator)(
             self.site,
             'imageusage',

--- a/mwclient/listing.py
+++ b/mwclient/listing.py
@@ -1,5 +1,5 @@
 from typing import (  # noqa: F401
-    Optional, Tuple, Any, Union, Iterator, Mapping, Iterable, Type, Dict
+    Optional, Tuple, Any, Union, Iterator, Mapping, MutableMapping, Iterable, Type, Dict
 )
 
 import mwclient.image
@@ -150,6 +150,45 @@ class List:
                 yield _prefix + key, value
 
     @staticmethod
+    def get_listing_args(
+        prefix: str, generator: bool, args: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        """Prefix and extend arguments for List and subclasses.
+
+        Args:
+            prefix: Prefix to apply to each parameter name in `args`.
+            generator: Whether this listing is an API generator.
+            args: Parameters to pass to the API.
+        """
+        prefixed_args = {}
+        prefix = List.get_prefix(prefix, generator)
+        for key, value in args.items():
+            if value is not None and value is not False:
+                prefixed_args[prefix + key] = value
+
+        return prefixed_args
+
+    @staticmethod
+    def get_page_listing_args(
+        prefix: str, generator: bool, with_content: bool, args: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        """Prefix and extend arguments for Lists returning pages.
+
+        Args:
+            prefix: Prefix to apply to each parameter name in `args`.
+            generator: Whether this listing is an API generator.
+            with_content: Whether the API should prefetch page content for returned items
+            args: Parameters to pass to the API.
+        """
+        prefixed_args = List.get_listing_args(prefix, generator, args)
+
+        if with_content:
+            prefixed_args['rvprop'] = 'content'
+            prefixed_args['prop'] = 'info|imageinfo|revisions'
+
+        return prefixed_args
+
+    @staticmethod
     def get_prefix(prefix: str, generator: bool = False) -> str:
         return ('g' if generator else '') + prefix
 
@@ -190,8 +229,8 @@ class GeneratorList(List):
         self.args['g' + self.prefix + 'limit'] = self.args[self.prefix + 'limit']
         del self.args[self.prefix + 'limit']
         self.generator = 'generator'
-
-        self.args['prop'] = 'info|imageinfo'
+        if 'prop' not in self.args:
+            self.args['prop'] = 'info|imageinfo'
         self.args['inprop'] = 'protection'
 
         self.result_member = 'pages'
@@ -254,12 +293,18 @@ class Category(mwclient.page.Page, GeneratorList):
         dir: str = 'asc',
         start: Optional[str] = None,
         end: Optional[str] = None,
-        generator: bool = True
+        generator: bool = True,
+        with_content: bool = False
     ) -> 'List':
-        prefix = self.get_prefix('cm', generator)
-        kwargs = dict(self.generate_kwargs(prefix, prop=prop, namespace=namespace,
-                                           sort=sort, dir=dir, start=start, end=end,
-                                           title=self.name))
+        kwargs = self.get_page_listing_args('cm', generator, with_content, {
+            'start': start,
+            'end': end,
+            'dir': dir,
+            'namespace': namespace,
+            'prop': prop,
+            'sort': sort,
+            'title': self.name
+        })
         return self.get_list(generator)(self.site, 'categorymembers', 'cm', **kwargs)
 
 

--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -184,6 +184,11 @@ class Page:
             cache: Use in-memory caching (default: `True`)
         """
 
+        # Try to use text from info if already supplied
+        if 'revisions' in self._info and len(self._info['revisions']) > 0:
+            if '*' in self._info['revisions'][0]:
+                return self._info['revisions'][0]['*']
+
         if not self.can('read'):
             raise mwclient.errors.InsufficientPermission(self)
         if not self.exists:
@@ -452,7 +457,8 @@ class Page:
         limit: Optional[int] = None,
         generator: bool = True,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> 'mwclient.listing.List':
         """List pages that link to the current page, similar to Special:Whatlinkshere.
 
@@ -460,13 +466,14 @@ class Page:
 
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        prefix = mwclient.listing.List.get_prefix('bl', generator)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(
-            prefix, namespace=namespace, filterredir=filterredir,
-        ))
-        if redirect:
-            kwargs[f'{prefix}redirect'] = '1'
-        kwargs[prefix + 'title'] = self.name
+
+        kwargs = mwclient.listing.List.get_page_listing_args(
+            'bl', generator, with_content, {
+                'namespace': namespace,
+                'filterredir': filterredir,
+                'title': self.name,
+                'redirect': '1' if redirect else None
+            })
 
         return mwclient.listing.List.get_list(generator)(
             self.site, 'backlinks', 'bl', max_items=max_items,
@@ -474,7 +481,10 @@ class Page:
         )
 
     def categories(
-        self, generator: bool = True, show: Optional[str] = None
+        self,
+        generator: bool = True,
+        show: Optional[str] = None,
+        with_content: bool = False
     ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List categories used on the current page.
 
@@ -488,10 +498,11 @@ class Page:
         Returns:
             mwclient.listings.PagePropertyGenerator
         """
-        prefix = mwclient.listing.List.get_prefix('cl', generator)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(
-            prefix, show=show
-        ))
+
+        kwargs = mwclient.listing.List.get_page_listing_args(
+            'cl', generator, with_content, {
+                'show': show
+            })
 
         if generator:
             return mwclient.listing.PagePropertyGenerator(
@@ -510,7 +521,8 @@ class Page:
         limit: Optional[int] = None,
         generator: bool = True,
         max_items: Optional[int] = None,
-        api_chunk_size: Optional[int] = None
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
     ) -> 'mwclient.listing.List':
         """List pages that transclude the current page.
 
@@ -524,15 +536,19 @@ class Page:
             generator: Return generator (Default: True)
             max_items: The maximum number of pages to yield
             api_chunk_size: The API request chunk size
+            with_content: Whether to prefetch content for returned pages
 
         Returns:
             mwclient.listings.List: Page iterator
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        prefix = mwclient.listing.List.get_prefix('ei', generator)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(prefix, namespace=namespace,
-                                                            filterredir=filterredir))
-        kwargs[prefix + 'title'] = self.name
+
+        kwargs = mwclient.listing.List.get_page_listing_args(
+            'ei', generator, with_content, {
+                'namespace': namespace,
+                'filterredir': filterredir,
+                'title': self.name,
+            })
 
         return mwclient.listing.List.get_list(generator)(
             self.site, 'embeddedin', 'ei', max_items=max_items,
@@ -584,15 +600,18 @@ class Page:
         self,
         namespace: Optional[Namespace] = None,
         generator: bool = True,
-        redirects: bool = False
+        redirects: bool = False,
+        with_content: bool = False
     ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List links to other pages from the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Links
 
         """
-        prefix = mwclient.listing.List.get_prefix('pl', generator)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(prefix, namespace=namespace))
+        kwargs = mwclient.listing.List.get_page_listing_args(
+            'pl', generator, with_content, {
+                'namespace': namespace
+            })
 
         if redirects:
             kwargs['redirects'] = '1'
@@ -651,10 +670,17 @@ class Page:
             mwclient.listings.List: Revision iterator
         """
         (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(
-            'rv', startid=startid, endid=endid, start=start, end=end, user=user,
-            excludeuser=excludeuser, diffto=diffto, slots=slots
-        ))
+
+        kwargs = mwclient.listing.List.get_listing_args('rv', False, {
+            'startid': startid,
+            'endid': endid,
+            'start': start,
+            'end': end,
+            'user': user,
+            'excludeuser': excludeuser,
+            'diffto': diffto,
+            'slots': slots
+        })
 
         if self.site.version[:2] < (1, 32) and 'rvslots' in kwargs:  # type: ignore[index]
             # https://github.com/mwclient/mwclient/issues/199
@@ -674,15 +700,21 @@ class Page:
                                                   **kwargs)
 
     def templates(
-        self, namespace: Optional[Namespace] = None, generator: bool = True
+        self,
+        namespace: Optional[Namespace] = None,
+        generator: bool = True,
+        with_content: bool = False
     ) -> Union['mwclient.listing.PagePropertyGenerator', 'mwclient.listing.PageProperty']:
         """List templates used on the current page.
 
         API doc: https://www.mediawiki.org/wiki/API:Templates
 
         """
-        prefix = mwclient.listing.List.get_prefix('tl', generator)
-        kwargs = dict(mwclient.listing.List.generate_kwargs(prefix, namespace=namespace))
+
+        kwargs = mwclient.listing.List.get_page_listing_args(
+            'tl', generator, with_content, {
+                'namespace': namespace
+            })
         if generator:
             return mwclient.listing.PagePropertyGenerator(self, 'templates', 'tl',
                                                           **kwargs)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -739,6 +739,48 @@ class TestClientApiMethods(TestCase):
         assert revisions[0]['timestamp'] == time.strptime('2015-11-08T21:52:46Z', '%Y-%m-%dT%H:%M:%SZ')
         assert revisions[1]['revid'] == 689816909
 
+    def test_allpages_with_content(self):
+        self.api.return_value = {
+            "query": {
+                "pages": {
+                    "1886677": {
+                        "pageid": 1886677,
+                        "ns": 0,
+                        "title": "Test",
+                        "contentmodel": "wikitext",
+                        "pagelanguage": "en",
+                        "pagelanguagehtmlcode": "en",
+                        "pagelanguagedir": "ltr",
+                        "touched": "2026-02-23T06:55:21Z",
+                        "lastrevid": 6267986,
+                        "length": 38,
+                        "redirect": "",
+                        "new": "",
+                        "protection": [],
+                        "restrictiontypes": [
+                            "edit",
+                            "move"
+                        ],
+                        "revisions": [
+                            {
+                                "contentmodel": "wikitext",
+                                "contentformat": "text/x-wiki",
+                                "*": "test content"
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+
+        pages = [p for p in self.site.allpages(with_content=True)]
+        args, _ = self.api.call_args
+
+        assert ('prop', 'info|imageinfo|revisions') in args
+        assert ('rvprop', 'content') in args
+        assert len(pages) == 1
+        assert pages[0].text() == 'test content'
+
 
 class TestVersionTupleFromGenerator:
 

--- a/test/test_listing.py
+++ b/test/test_listing.py
@@ -297,6 +297,52 @@ class TestList(unittest.TestCase):
         assert type(vals[2]) == mwclient.listing.Category
 
     @mock.patch('mwclient.client.Site')
+    def test_pagelist_with_content(self, mock_site):
+        mock_site.__str__.return_value = 'some wiki'
+        mock_site.api_limit = 500
+        mock_site.get.return_value = {
+            "query": {
+                "pages": {
+                    "1886677": {
+                        "pageid": 1886677,
+                        "ns": 0,
+                        "title": "Test",
+                        "contentmodel": "wikitext",
+                        "pagelanguage": "en",
+                        "pagelanguagehtmlcode": "en",
+                        "pagelanguagedir": "ltr",
+                        "touched": "2026-02-23T06:55:21Z",
+                        "lastrevid": 6267986,
+                        "length": 38,
+                        "redirect": "",
+                        "new": "",
+                        "protection": [],
+                        "restrictiontypes": [
+                            "edit",
+                            "move"
+                        ],
+                        "revisions": [
+                            {
+                                "contentmodel": "wikitext",
+                                "contentformat": "text/x-wiki",
+                                "*": "test content"
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+
+        gl = GeneratorList(mock_site, 'pages', 'p', prop='info|imageinfo|revisions')
+        assert gl.args['prop'] == 'info|imageinfo|revisions'
+
+        vals = [x for x in gl];
+    
+        assert len(vals) == 1
+        assert type(vals[0]) == mwclient.page.Page
+        assert vals[0].text() == 'test content'
+
+    @mock.patch('mwclient.client.Site')
     def test_category(self, mock_site):
         # Test that Category works as expected
 
@@ -462,6 +508,34 @@ class TestList(unittest.TestCase):
         vals = [x for x in rvi]
         assert len(vals) == 0
 
+
+class TestGetListingArgs:
+
+    @pytest.mark.parametrize('prefix, generator, args, expected', [
+        ('au', False, { 'from': 'Test', 'limit': 500, 'exclude': None }, { 'aufrom': 'Test', 'aulimit': 500 }),
+        ('ap', True, { 'from': 'Test', 'limit': 500, 'other': False }, { 'gapfrom': 'Test', 'gaplimit': 500 })
+    ])
+    def test_get_listing_args(self, prefix, generator, args, expected):
+        assert List.get_listing_args(prefix, generator, args) == expected
+
+    @pytest.mark.parametrize('prefix, generator, with_content, args, expected', [
+        ('ap', True, False, { 'from': 'Test', 'limit': 500, 'other': False }, { 'gapfrom': 'Test', 'gaplimit': 500 }),
+        ('ap', True, True, { 'from': 'Test', 'limit': 500, 'other': False }, {
+            'gapfrom': 'Test',
+            'gaplimit': 500,
+            'prop': 'info|imageinfo|revisions',
+            'rvprop': 'content'
+            }),
+        ('bl', False, False, { 'from': 'Test', 'limit': 500, 'other': False }, { 'blfrom': 'Test', 'bllimit': 500 }),
+        ('bl', False, True, { 'from': 'Test', 'limit': 500, 'other': False }, {
+            'blfrom': 'Test',
+            'bllimit': 500,
+            'prop': 'info|imageinfo|revisions',
+            'rvprop': 'content'
+            })
+    ])
+    def test_get_page_listing_args(self, prefix, generator, with_content, args, expected):
+        assert List.get_page_listing_args(prefix, generator, with_content, args) == expected
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -331,6 +331,31 @@ class TestPage(unittest.TestCase):
         assert not page.exists, 'Page should not exist after move'
         assert not page.redirect, 'Page should not be a redirect after move'
 
+    @mock.patch('mwclient.client.Site')
+    def test_page_uses_prefetched_content(self, mock_site):
+        page_title = 'Some page'
+        page = Page(mock_site, page_title, info={
+            'contentmodel': 'wikitext',
+            'counter': '',
+            'lastrevid': 13355471,
+            'length': 58487,
+            'ns': 0,
+            'pageid': 728,
+            'pagelanguage': 'nb',
+            'protection': [],
+            'title': page_title,
+            'touched': '2014-09-14T21:11:52Z',
+            'revisions': [
+                {
+                    "contentformat": "text/x-wiki",
+                    "contentmodel": "wikitext",
+                    "*": "Some content"
+                }
+            ]
+        })
+
+        assert page.text() == 'Some content'
+
 
 class TestPageApiArgs(unittest.TestCase):
 


### PR DESCRIPTION
Currently operations on page lists that require accessing page content fetch the content separately for each page in the list. This is rather inefficient for common workflows such as transforming the content of a list of pages since a separate HTTP request needs to be issued to fetch the content for each page.

So, add a new optional `with_content` parameter to methods that enumerate pages and have List set appropriate parameters in this case so that the list response itself includes page contents and have `Page` look for page content in the info it was constructed with first. Add two new helpers to generate proper arguments for listing classes to avoid needing to duplicate the requisite logic across all call sites.