### PR TITLE
Support formatversion=2 variants in Page.text

### DIFF
--- a/mwclient/page.py
+++ b/mwclient/page.py
@@ -203,9 +203,10 @@ class Page:
         try:
             rev = next(revs)
             if 'slots' in rev:
-                text = rev['slots'][slot]['*']
+                slot_data = rev['slots'].get(slot, {})
+                text = slot_data.get('*', slot_data.get('content', ''))
             else:
-                text = rev['*']
+                text = rev.get('*', rev.get('content', ''))
             self.last_rev_time = rev['timestamp']
         except StopIteration:
             text = ''

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -381,6 +381,34 @@ class TestPageApiArgs(unittest.TestCase):
             'rvslots': 'main',
         }
 
+    def test_get_page_text_from_formatversion2_slot_content(self):
+        self.site.get.return_value = {'query': {'pages': {'2': {
+            'ns': 0,
+            'pageid': 2,
+            'revisions': [{
+                'slots': {'main': {'content': self.page_text}},
+                'timestamp': '2014-08-29T22:25:15Z',
+            }],
+            'title': self.page.page_title
+        }}}}
+
+        text = self.page.text()
+        assert text == self.page_text
+
+    def test_get_page_text_with_missing_slot_content(self):
+        self.site.get.return_value = {'query': {'pages': {'2': {
+            'ns': 0,
+            'pageid': 2,
+            'revisions': [{
+                'slots': {'main': {}},
+                'timestamp': '2014-08-29T22:25:15Z',
+            }],
+            'title': self.page.page_title
+        }}}}
+
+        text = self.page.text()
+        assert text == ''
+
     def test_get_page_text_cached(self):
         # Check page.text() caching
         self.page.revisions = mock.Mock(return_value=iter([]))  # type: ignore


### PR DESCRIPTION
Support formatversion=2 'content' keys when reading revision text.

Fixes

```
  File "/lib/python3.13/site-packages/mwclient/page.py", line 161, in text
    text = rev['slots'][slot]['*']
           ~~~~~~~~~~~~~~~~~~^^^^^
KeyError: '*'
```

AI-assisted.