### PR TITLE
Documentation copy-editing to keep examples consistant and types correct

### DIFF
--- a/docs/source/user/connecting.rst
+++ b/docs/source/user/connecting.rst
@@ -87,7 +87,7 @@ using the `connection_options` parameter of the :class:`~mwclient.client.Site`.
       'http': 'http://10.10.1.10:3128',
       'https': 'http://10.10.1.10:1080',
     }
-    site = mwclient.Site('en.wikipedia.org', connection_options={"proxy": proxies})
+    site = mwclient.Site('en.wikipedia.org', connection_options={"proxies": proxies})
 
 Errors and warnings
 -------------------

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -11,12 +11,12 @@ Getting info about a file
 
 To get information about a file:
 
-    >>> file = site.images['Example.jpg']
+    >>> image = site.images['Example.jpg']
 
-where ``file`` is now an instance of :class:`Image <mwclient.image.Image>`
+where ``image`` is now an instance of :class:`Image <mwclient.image.Image>`
 that you can query for various properties:
 
-    >>> file.imageinfo
+    >>> image.imageinfo
     {'comment': 'Reverted to version as of 17:58, 12 March 2010',
      'descriptionshorturl': 'https://commons.wikimedia.org/w/index.php?curid=6428847',
      'descriptionurl': 'https://commons.wikimedia.org/wiki/File:Example.jpg',
@@ -51,7 +51,7 @@ The :meth:`Image.download() <mwclient.image.Image.download>` method can be used 
 the full size file. Pass it a file object and it will stream the image to it,
 avoiding the need for keeping the whole file in memory:
 
-    >>> file = site.images['Example.jpg']
+    >>> image = site.images['Example.jpg']
     >>> with open('Example.jpg', 'wb') as fd:
     ...     image.download(fd)
 

--- a/docs/source/user/implementation-notes.rst
+++ b/docs/source/user/implementation-notes.rst
@@ -32,4 +32,4 @@ without its namespace prefixed.
     >>> image = site.Pages['Image:Wiki.png'] # an Image object
     >>> image = site.Images['Wiki.png']      # the same Image object
     >>> cat = site.Pages['Category:Python']  # a Category object
-    >>> cat = site.Images['Python']          # the same Category object
+    >>> cat = site.Categories['Python']      # the same Category object

--- a/docs/source/user/page-ops.rst
+++ b/docs/source/user/page-ops.rst
@@ -70,7 +70,7 @@ Categories
 ----------
 
 Categories can be retrieved in the same way as pages, but you can also use
-:meth:`Site.categories() <mwclient.client.Site.categories>` and skip the namespace prefix.
+:attr:`Site.categories <mwclient.client.Site.categories>` and skip the namespace prefix.
 The returned :class:`Category <mwclient.listing.Category>` object
 supports the same methods as the :class:`Page <mwclient.page.Page>`
 object, but also provides an extra function, :meth:`members() <mwclient.listing.Category.members>`,


### PR DESCRIPTION
Copy-edit Consistent naming of image variable in the files.rst doccumentation

Copy-edit typo Images -> Categories to be consistent with the example

Copy-edit proxy -> proxies to respect request signature
    proxies: dict[str, str] | None = None

Copy-edit Site.categories is not :meth: but :attr:

@AdamWill or @waldyrious if you can have a look at this, I think it improves the documentation (we can do better on the Pages, Images, Categories compatibility generator but that's a start)