### PR TITLE
feat: add Site.category_members

### DIFF
--- a/docs/source/user/implementation-notes.rst
+++ b/docs/source/user/implementation-notes.rst
@@ -8,7 +8,7 @@ Some notable exceptions:
 
 * ``Image.imageinfo`` is the imageinfo of the latest image. Earlier versions can be fetched using ``imagehistory()``.
 * ``Site.all*``: parameter ``(ap)from`` renamed to ``start``
-* ``categorymembers`` is implemented as ``Category.members``
+* ``categorymembers`` is available as ``Site.category_members`` or ``Category.members``
 * ``deletedrevs`` is ``deletedrevisions``
 * ``usercontribs`` is ``usercontributions``
 * First parameters of ``search`` and ``usercontributions`` are ``search`` and ``user``, respectively

--- a/mwclient/client.py
+++ b/mwclient/client.py
@@ -1489,6 +1489,42 @@ class Site:
                                                 max_items=max_items,
                                                 api_chunk_size=api_chunk_size, **kwargs)
 
+    def category_members(
+        self,
+        category: str,
+        prop: str = 'ids|title',
+        namespace: Optional[Namespace] = None,
+        sort: str = 'sortkey',
+        dir: str = 'asc',
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        limit: Optional[int] = None,
+        generator: bool = True,
+        max_items: Optional[int] = None,
+        api_chunk_size: Optional[int] = None,
+        with_content: bool = False
+    ) -> listing.List:
+        """Retrieve pages that belong to a category.
+
+        API doc: https://www.mediawiki.org/wiki/API:Categorymembers
+        """
+        (max_items, api_chunk_size) = handle_limit(limit, max_items, api_chunk_size)
+
+        kwargs = listing.List.get_page_listing_args('cm', generator, with_content, {
+            'title': category,
+            'prop': prop,
+            'namespace': namespace,
+            'sort': sort,
+            'dir': dir,
+            'start': start,
+            'end': end
+        })
+
+        return listing.List.get_list(generator)(
+            self, 'categorymembers', 'cm', max_items=max_items,
+            api_chunk_size=api_chunk_size, **kwargs
+        )
+
     def allusers(
         self,
         start: Optional[str] = None,

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -781,6 +781,34 @@ class TestClientApiMethods(TestCase):
         assert len(pages) == 1
         assert pages[0].text() == 'test content'
 
+    def test_category_members_with_content(self):
+        self.api.return_value = {
+            "query": {
+                "pages": {
+                    "1886677": {
+                        "pageid": 1886677,
+                        "ns": 0,
+                        "title": "Test",
+                        "revisions": [{"*": "test content"}],
+                    },
+                }
+            }
+        }
+
+        pages = list(self.site.category_members(
+            "Category:Examples", namespace=0, max_items=1, with_content=True
+        ))
+        args, _ = self.api.call_args
+
+        assert ("generator", "categorymembers") in args
+        assert ("gcmtitle", "Category:Examples") in args
+        assert ("gcmnamespace", 0) in args
+        assert ("prop", "info|imageinfo|revisions") in args
+        assert ("rvprop", "content") in args
+        assert ("gcmlimit", "1") in args
+        assert len(pages) == 1
+        assert pages[0].text() == "test content"
+
 
 class TestVersionTupleFromGenerator:
 


### PR DESCRIPTION
## Summary

- I added `Site.category_members()` as a direct, consistent entry point for MediaWiki's `categorymembers` API.
- I exposed generator, pagination, filtering, sorting, and `with_content` options through the new method.
- I documented the new access path and added regression coverage for prefetched page content.

## Validation

- `.venv/bin/python -m pytest -q` — 116 passed
- `.venv/bin/flake8 mwclient`
- `.venv/bin/mypy`
- `.venv/bin/python -m sphinx -b html docs/source docs/build/html` — completed successfully (existing documentation warnings remain)
- `git diff --check`

I deferred the container-based integration suite to CI because the project documentation notes that it requires roughly 3 GB of image downloads.

Fixes #418
